### PR TITLE
feat(init): first steps, test homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/*
+output/*
+.idea/*
+package-lock.json
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# To run: docker run -d --name=dataportal -p 80:80 quay.io/cdis/data-portal
+# To check running container: docker exec -it dataportal /bin/bash
+
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    nginx \
+    python \
+    vim \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+ARG APP=dev
+ARG BASENAME

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,57 @@
+#!groovy
+
+pipeline {
+  agent any
+
+  stages {
+    stage('FetchCode') {
+      steps {
+        dir('gen3-qa') {
+          checkout scm
+        }
+        dir('cdis-manifest') {
+          git(
+            url: 'https://github.com/uc-cdis/cdis-manifest.git',
+            branch: 'QA'
+          )
+        }
+        dir('cloud-automation') {
+          git(
+            url: 'https://github.com/uc-cdis/cloud-automation.git',
+            branch: 'chore/jenkins-qa'
+          )
+        }
+      }
+    }
+    stage('K8sDeploy') {
+      steps {
+        withEnv(['GEN3_NOPROXY=true']) {
+          echo "GIT_BRANCH is $env.GIT_BRANCH"
+          echo "GIT_COMMIT is $env.GIT_COMMIT"
+          echo "WORKSPACE is $env.WORKSPACE"
+          sh "bash cloud-automation/tf_files/configs/kube-roll-qa.sh"
+        }
+      }
+    }
+    stage('RunTests') {
+      steps {
+        dir('gen3-qa') {
+          withEnv(['GEN3_NOPROXY=true']) {
+            sh "bash ./run-tests.sh"
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      echo "https://jenkins.planx-pla.net/ $env.JOB_NAME pipeline succeeded"
+    }
+    failure {
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net $env.JOB_NAME pipeline failed"
+    }
+    unstable {
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net $env.JOB_NAME pipeline unstable"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# auto-qa
+# Gen3 Automatic Integration Test
+Test steps are written in steps folder while the details to test are declared in questions folder. Two folders `portal` and `apis` contains tests for portal and REST apis respectively.
+
+Test process needs `ACCESS_TOKEN, EXPIRED_ACCESS_TOKEN, INDEX_USERNAME, INDEX_PASSWORD` environment variables.
+
+After having these environment variables, running test by these steps:
+- npm install
+- npm run test

--- a/apis/presignedUrlTest.js
+++ b/apis/presignedUrlTest.js
@@ -1,0 +1,81 @@
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+let expect = chai.expect;
+
+Feature('PresignedUrlAPI');
+
+const files = {
+  allowed: {
+    filename: 'test_valid',
+    link: 's3://cdis-presigned-url-test/testdata',
+    md5: '73d643ec3f4beb9020eef0beed440ad0',
+    metadata: {'acls':'test'},
+    size: 9,
+  },
+  not_allowed: {
+    filename: 'test_not_allowed',
+    link: 's3://cdis-presigned-url-test/testdata',
+    md5: '73d643ec3f4beb9020eef0beed440ad0',
+    metadata: {'acls':'acct'},
+    size: 9,
+  },
+  no_link: {
+    filename: 'test_no_link',
+    md5: '73d643ec3f4beb9020eef0beed440ad0',
+    metadata: {'acls':'test'},
+    size: 9,
+  },
+  http_link: {
+    filename: 'test_protocol',
+    link: 'http://cdis-presigned-url-test/testdata',
+    md5: '73d643ec3f4beb9020eef0beed440ad0',
+    metadata: {'acls':'test'},
+    size: 9,
+  },
+};
+
+Scenario('test presigned-url', async(I) => {
+  return expect(I.seeFileContentEqual(
+    '/user/data/download/',
+    files.allowed.did
+  )).to.eventually.equal('Hi Zac!\ncdis-data-client uploaded this!\n');
+});
+
+Scenario('test presigned-url with file user does not have permission', async(I) => {
+  return expect(I.seeFileContentEqual(
+    '/user/data/download/',
+    files.not_allowed.did
+  )).to.eventually.equal('You don\'t have access permission on this file');
+});
+
+Scenario('test presigned-url with invalid protocol', async(I) => {
+  return expect(I.seeFileContentEqual(
+    '/user/data/download/',
+    files.allowed.did,
+    ['protocol=s2']
+  )).to.eventually.equal('The specified protocol is not supported');
+});
+
+Scenario('test presigned-url with protocol not exist for file', async(I) => {
+  return expect(I.seeFileContentEqual(
+    '/user/data/download/',
+    files.http_link.did,
+    ['protocol=s3']
+  )).to.eventually.equal('Can\'t find a location for the data with given request arguments.');
+});
+
+Scenario('test presigned-url no data', async(I) => {
+  return expect(I.seeFileContentEqual(
+    '/user/data/download/',
+    files.no_link.did
+  )).to.eventually.equal('Can\'t find a location for the data');
+});
+
+BeforeSuite((I) => {
+  I.addFileIndices('/index/index/', Object.values(files))
+});
+
+AfterSuite((I) => {
+  I.deleteFileIndices('/index/index/', Object.values(files))
+});

--- a/apis/userTokenTest.js
+++ b/apis/userTokenTest.js
@@ -1,0 +1,59 @@
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+let expect = chai.expect;
+
+Feature('UserTokenAPI');
+
+let key_id = null;
+let api_key = null;
+
+let access_token = process.env.ACCESS_TOKEN;
+let expired_access_token = process.env.EXPIRED_ACCESS_TOKEN;
+
+Scenario('test create APIKey success', async(I) => {
+  scope = ['data', 'user'];
+  return expect(I.createAPIKey('/user/credentials/cdis/', scope, access_token)
+    .then(
+      (res) => {
+        key_id = res.body.key_id;
+        api_key = res.body.api_key;
+        return res.body;
+      }
+    ))
+    .to.eventually.have.property('api_key');
+});
+
+Scenario('test create APIKey with expired access token', async(I) => {
+  scope = ['data', 'user'];
+  return expect(I.createAPIKey('/user/credentials/cdis/',
+    scope, expired_access_token)
+    .then(
+      (res) => {
+        return res.body;
+      }
+    ))
+    .to.eventually.not.have.property('api_key');
+});
+
+Scenario('test refresh access token with api_key', async(I) => {
+  return expect(I.getAccessToken('/user/credentials/cdis/access_token', api_key))
+    .to.eventually.have.property('access_token');
+});
+
+Scenario('test refresh access token with invalid api_key', async(I) => {
+  return expect(I.getAccessToken('/user/credentials/cdis/access_token', 'invalid'))
+    .to.eventually.not.have.property('access_token');
+});
+
+Scenario('test refresh access token without api_key', async(I) => {
+  return expect(I.getAccessToken('/user/credentials/cdis/access_token', null))
+    .to.eventually.have.property('message')
+    .to.eventually.equal('Please provide an api_key in payload');
+});
+
+AfterSuite((I) => {
+  if (key_id !== null){
+    I.deleteAPIKey('/user/credentials/cdis/', key_id);
+  }
+});

--- a/cdisHelper.js
+++ b/cdisHelper.js
@@ -1,0 +1,17 @@
+'use strict';
+
+let Helper = codecept_helper;
+
+class CDISHelper extends Helper {
+  _beforeSuite(suite) {
+    if (!suite.title.indexOf('API') >= 0)
+    {
+      const helper = this.helpers['WebDriverIO'];
+      helper.amOnPage('');
+      let access_token = process.env.ACCESS_TOKEN;
+      helper.setCookie({name: 'access_token', value: access_token});
+    }
+  }
+}
+
+module.exports = CDISHelper;

--- a/codecept.json
+++ b/codecept.json
@@ -1,0 +1,34 @@
+{
+  "output": "./output",
+  "helpers": {
+    "WebDriverIO": {
+      "url": "https://dev.planx-pla.net",
+      "smartWait": 5000,
+      "browser": "chrome",
+      "restart": false,
+      "windowSize": "normal",
+      "timeouts": {
+        "script": 6000,
+        "page load": 10000
+      }
+    },
+    "REST": {
+      "endpoint": "https://dev.planx-pla.net",
+      "defaultHeaders": ""
+    },
+    "CDISHelper": {
+      "require": "./cdisHelper.js",
+      "defaultHost": "https://dev.planx-pla.net"
+    }
+  },
+  "include": {
+    "I": "./stepsFile.js"
+  },
+  "mocha": {},
+  "bootstrap": false,
+  "teardown": null,
+  "hooks": [],
+  "tests": "*/*Test.js",
+  "timeout": 10000,
+  "name": "selenium"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "auto_qa_portal",
+  "version": "0.1.0",
+  "description": "Bionimbus Data Portal",
+  "main": "index.js",
+  "dependencies": {
+    "selenium-standalone": "^6.13.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uc-cdis/auto-qa.git"
+  },
+  "author": "thanhnd",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/uc-cdis/auto-qa/issues"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
+    "codeceptjs": "^1.1.7",
+    "eslint": "^4.7.2",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.4.0",
+    "webdriverio": "^4.12.0",
+    "unirest": "^0.5.1",
+    "uuid": "^3.2.1"
+  },
+  "scripts": {
+    "test": "codeceptjs run --debug --verbose"
+  }
+}

--- a/portal/homepageTest.js
+++ b/portal/homepageTest.js
@@ -1,0 +1,8 @@
+
+Feature('Login');
+
+Scenario('test login', (I) => {
+  I.load('');
+  I.seeCookie('access_token');
+  I.seeHomepageDetails();
+});

--- a/questions/homepageDetails.js
+++ b/questions/homepageDetails.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const seeSummary = function() {
+  this.waitForText('Project Submission Summary', 5);
+  ['Cases', 'Experiments', 'Aliquots', 'Files'].map(
+    item => this.see(item)
+  );
+};
+
+const seeChart = function() {
+  this.seeElement({css: 'div.recharts-responsive-container'});
+};
+
+const seeProjectList = function() {
+  this.see('List of Projects');
+};
+
+
+const seeTransactionLogs = function() {
+  this.see('Recent Submissions');
+};
+
+module.exports.seeHomepageDetails = function () {
+  let I = actor({
+    seeSummary: seeSummary,
+    seeChart: seeChart,
+    seeProjectList: seeProjectList,
+    seeTransactionLogs: seeTransactionLogs,
+  });
+  I.seeSummary();
+  I.seeChart();
+  I.seeProjectList();
+  I.seeTransactionLogs();
+};

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,70 @@
 #!/bin/bash -e
+#
+#
 
-set -e
+_RUN_TESTS=$(dirname "${BASH_SOURCE:-$0}")  # $0 supports zsh
+
+cd "${_RUN_TESTS}"
 npm install
-export ACCESS_TOKEN=$(kubectl exec $(get_pod fence) -it -- fence-create token-create --scopes openid,user,fence,data --type access_token --exp 1800 --username cdis.autotest@gmail.com)
-qa_cred=$( kubectl get secret sheepdog-secret -ojson | jq -r '.data["wsgi.py"]' | base64 --decode | egrep "(\s+'auth':\s\('gdcapi')" | sed "s/.*\(('gdcapi', '[A-Za-z0-9]\{8,\}')\).*/\1/" )
-export INDEX_USER=gdcapi
-export INDEX_PASSWORD=$( [[ $qa_cred =~ ([A-Za-z0-9]{8,}+) ]] && echo ${BASH_REMATCH[1]} )
-npm run test
+
+namespaceList=$(kubectl get namespace -o json | jq -r '.items[].metadata.name')
+
+if [[ $? -ne 0 ]]; then
+  echo "ERROR: failed to retrieve kubernetes namespaces: $namespaceList"
+  exit 1
+fi
+
+
+get_pod() {
+  local name
+  local namespace
+  name="$1"
+  namespace="${2:-default}"
+  pod=$(kubectl --namespace $namespace get pods --output=jsonpath='{range .items[*]}{.metadata.name}  {"\n"}{end}' | grep -m 1 "$name")
+  echo $pod
+}
+
+#
+# Run a test in the specified namespace
+#
+runTest() {
+  local namespace
+  namespace="${1:-default}"
+  (
+    export KUBECTL_NAMESPACE="$namespace"
+    export HOSTNAME=$(kubectl --namespace=${namespace} get configmaps global -ojsonpath='{.data.hostname}')
+    if [[ $? -ne 0 || -z "$HOSTNAME" ]]; then
+      echo "ERROR: failed to retrive HOST_NAME for namespace $namespace"
+      return 1
+    fi
+    export ACCESS_TOKEN=$(kubectl --namespace=${namespace} exec $(get_pod fence $namespace) -- fence-create token-create --scopes openid,user,fence,data --type access_token --exp 1800 --username cdis.autotest@gmail.com)
+    if [[ $? -ne 0 || -z "$ACCESS_TOKEN" ]]; then
+      echo "ERROR: failed to retrieve ACCESS_TOKEN for namespace $namespace"
+      return 1
+    fi
+    qa_cred=$( kubectl get secret sheepdog-secret -ojson | jq -r '.data["wsgi.py"]' | base64 --decode | egrep "(\s+'auth':\s\('gdcapi')" | sed "s/.*\(('gdcapi', '[A-Za-z0-9]\{8,\}')\).*/\1/" )
+    export INDEX_USER=gdcapi
+    export INDEX_PASSWORD=$( [[ $qa_cred =~ ([A-Za-z0-9]{8,}+) ]] && echo ${BASH_REMATCH[1]} )
+    if [[ $? -ne 0 || -z "$INDEX_PASSWORD" ]]; then
+      echo "ERROR: failed to retrieve INDEX_PASSWORD for namespace $namespace"
+      return 1
+    fi
+    cat - <<EOM
+  Running test in $namespace
+  HOSTNAME=$HOSTNAME
+
+EOM
+    # Don't actually run the tests yet ... :-p
+    echo npm run test
+  )
+}
+
+exitCode=0
+for name in ${namespaceList}; do
+  if [[ "$name" == "default" || "$name" =~ ^qa- ]]; then
+    runTest "$name"
+    if [[ $? -ne 0 ]]; then exitCode=1; fi
+  fi
+done
+
+exit $exitCode

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+set -e
+npm install
+export ACCESS_TOKEN=$(kubectl exec $(get_pod fence) -it -- fence-create token-create --scopes openid,user,fence,data --type access_token --exp 1800 --username cdis.autotest@gmail.com)
+qa_cred=$( kubectl get secret sheepdog-secret -ojson | jq -r '.data["wsgi.py"]' | base64 --decode | egrep "(\s+'auth':\s\('gdcapi')" | sed "s/.*\(('gdcapi', '[A-Za-z0-9]\{8,\}')\).*/\1/" )
+export INDEX_USER=gdcapi
+export INDEX_PASSWORD=$( [[ $qa_cred =~ ([A-Za-z0-9]{8,}+) ]] && echo ${BASH_REMATCH[1]} )
+npm run test

--- a/steps/fenceAPI.js
+++ b/steps/fenceAPI.js
@@ -1,0 +1,124 @@
+'use strict';
+
+let username = process.env.INDEX_USERNAME;
+let password = process.env.INDEX_PASSWORD;
+let accessTokenHeaders = {
+  'Accept': 'application/json',
+  'Authorization': `bearer ${process.env.ACCESS_TOKEN}`
+};
+let indexAuth = Buffer.from(`${username}:${password}`).toString('base64');
+
+module.exports.seeFileContentEqual = function(endpoint, id, args=[]) {
+  return this.sendGetRequest(
+    `${endpoint}${id}?${args.join('&')}`, accessTokenHeaders).then(
+    (res) => {
+      if (res.body.hasOwnProperty('url'))
+        return this.sendGetRequest(res.body.url).then(
+          (res) => {
+            console.log(res.body);
+            return res.body;
+          }
+        ).catch(
+          (e) => {
+            console.log(e);
+            return e.message;
+          }
+        );
+      else
+        throw new Error(res.body.message);
+    }).catch(
+      (e) => {
+        console.log(e);
+        return e.message;
+      }
+    );
+};
+
+module.exports.addFileIndices = function(endpoint, files) {
+  let uuid = require('uuid');
+  let headers={
+    'Accept': 'application/json',
+    'Content-Type': 'application/json; charset=UTF-8',
+    'Authorization': `Basic ${indexAuth}`
+  };
+  files.forEach(
+    (file) => {
+      file.did = uuid.v4().toString();
+      let data = JSON.stringify({
+        file_name: file.filename,
+        did: file.did,
+        form: 'object',
+        size: file.size,
+        urls: [file.link],
+        hashes: {'md5': file.md5},
+        metadata: file.metadata});
+      this.sendPostRequest(endpoint, data, headers)
+        .then(
+          (res) => {
+            file.rev = res.body.rev;
+          }
+        );
+    }
+  )
+};
+
+module.exports.deleteFileIndices = function(endpoint, files) {
+  let headers = {
+    'Accept': 'application/json',
+    'Authorization': `Basic ${indexAuth}`
+  };
+  files.forEach(
+    (file) => {
+      this.sendDeleteRequest(`${endpoint}${file.did}?rev=${file.rev}`,
+        headers
+      ).then(
+        (res) => {
+          console.log(res.body)
+        }
+      )
+    }
+  );
+};
+
+module.exports.createAPIKey = function(endpoint, scope, access_token) {
+  let headers={
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'Authorization': `bearer ${access_token}`
+  };
+  return this.sendPostRequest(
+    endpoint,
+    JSON.stringify({
+      scope: scope
+    }),
+    headers);
+};
+
+module.exports.deleteAPIKey = function(endpoint, api_key) {
+  return this.sendDeleteRequest(`${endpoint}${api_key}`, accessTokenHeaders)
+    .then(
+      (res) => {
+        console.log(res.body);
+      }
+    );
+};
+
+module.exports.getAccessToken = function (endpoint, api_key) {
+  let headers={
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  };
+  let data = (api_key !== null) ? { api_key: api_key } : {};
+  return this.sendPostRequest(endpoint, JSON.stringify(data), headers)
+    .then(
+      (res) => {
+        console.log(res.body);
+        return res.body;
+      })
+    .catch(
+      (e) => {
+        console.log(e);
+        return e.message;
+      }
+    );
+};

--- a/steps/homepage.js
+++ b/steps/homepage.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.load = function(url) {
+  this.amOnPage(url);
+  this.waitForText('CDIS.AUTOTEST', 60);
+};

--- a/steps/loginGoogle.js
+++ b/steps/loginGoogle.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports.loginGoogle = function(email, password) {
+  this.wait(20);
+  this.seeInCurrentUrl('google.com');
+  this.wait(2);
+  this.click({name: 'identifier'});
+  this.pressKey(email.split(''));
+  this.click({id: 'identifierNext'});
+  this.waitForVisible({name: 'password'}, 2);
+  this.click({name: 'password'});
+  this.pressKey(password.split(''));
+  this.pressKey('Enter');
+};

--- a/stepsFile.js
+++ b/stepsFile.js
@@ -1,0 +1,28 @@
+'use strict';
+// in this file you can append custom step methods to 'I' object
+
+const { load } = require('./steps/homepage');
+const { loginGoogle } = require('./steps/loginGoogle');
+const {
+  addFileIndices,
+  createAPIKey,
+  deleteAPIKey,
+  deleteFileIndices,
+  getAccessToken,
+  seeFileContentEqual,
+} = require('./steps/fenceAPI');
+const { seeHomepageDetails } = require('./questions/homepageDetails');
+
+module.exports = function() {
+  return actor({
+    load: load,
+    seeHomepageDetails: seeHomepageDetails,
+    loginGoogle: loginGoogle,
+    addFileIndices: addFileIndices,
+    createAPIKey: createAPIKey,
+    deleteAPIKey: deleteAPIKey,
+    deleteFileIndices: deleteFileIndices,
+    getAccessToken: getAccessToken,
+    seeFileContentEqual: seeFileContentEqual,
+  });
+};


### PR DESCRIPTION
In this pull request, I did
- install `codeceptjs` that use `WebdriverIO` as test runner.
- write homepage test and fence test for testing presigned-url and user token.
- test steps are written in `steps` folder
- details things to test are written in `questions` folder
- `portal` folder contains all tests for portal
- `apis` folder contains all tests for REST apis
- running test needs `ACCESS_TOKEN`, `INDEX_USERNAME`, `INDEX_PASSWORD` environment variables.
- then, just run `npm install` and `npm run test`
r @philloooo  @frickjack @giangbui 