### PR TITLE
refactor(test_setup): add multiple tries for program/project creation

### DIFF
--- a/test_setup.js
+++ b/test_setup.js
@@ -97,6 +97,32 @@ function assertEnvVars(varNames) {
   });
 }
 
+/**
+ * Attempts to create a program and project
+ * Throws an error if unable to do so
+ * @param {string} nAttempts - number of times to try creating the program/project
+ * @returns {Promise<void>}
+ */
+async function tryCreateProgramProject(nAttempts) {
+  let success = false;
+  for (const i of [...Array(nAttempts).keys()]) {
+    if (success === true) {
+      break;
+    }
+    await commonsUtil.createProgramProject()
+      .then(() => {         // eslint-disable-line
+        console.log(`Successfully created program/project on attempt ${i}`);
+        success = true;
+      })
+      .catch((err) => {
+        console.log(`Failed to create program/project on attempt ${i}:\n`, JSON.stringify(err));
+        if (i === nAttempts - 1) {
+          throw err;
+        }
+      });
+  }
+}
+
 module.exports = async function (done) {
   // get some vars from the commons
   console.log('Setting environment variables...\n');
@@ -160,6 +186,6 @@ module.exports = async function (done) {
 
   // Create a program and project (does nothing if already exists)
   console.log('Creating program/project\n');
-  await commonsUtil.createProgramProject();
+  await tryCreateProgramProject(3);
   done();
 };

--- a/utils/commonsUtil.js
+++ b/utils/commonsUtil.js
@@ -66,14 +66,14 @@ module.exports = {
         if (error) {
           reject(error);
         }
-        if (response.statusCode !== 200) {
+        if (!response || response.statusCode !== 200) {
           reject(body);
         } else {
           request.post(projectForm, (err, res, bod) => {
             if (err) {
               reject(err);
             }
-            if (res.statusCode !== 200) {
+            if (!res || res.statusCode !== 200) {
               reject(bod);
             } else {
               resolve();


### PR DESCRIPTION
There is an occasional error in test_setup in function trying to create the program project, where the response and error were both undefined, and we'd throw an error because we were trying to check `response.statusCode`.
* added additional check to see if response is undefined before looking at status code
* added method in test_setup for attempting to create program/project multiple times