### PR TITLE
fix(login-logout): remove default login; add logout logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can kill the server with `npm run selenium-kill`
 ## Running Tests
 Once you have your environment variables configured and the Selenium server is running, you should be able to successfully run the tests.
 
-If you want to run `gen3-qa` against a dev environment, you just need to set the environment variable `NAMESPACE={dev env namespace}` and the `GOOGLE_APP_CREDS_JSON` to the credentials getting from Google, then run `./run-tests-localsh`.
+If you want to run `gen3-qa` against a dev environment, you just need to set the environment variable `NAMESPACE={dev env namespace}` and the `GOOGLE_APP_CREDS_JSON` to the credentials getting from Google, then run `./run-tests-local.sh`.
 
 But as mentioned above, some tests have special requirements so you may not want to run them. Instead, you can run a selection of tests that have certain tag by altering the line in `run-tests-local.sh` file `npm test -- --grep "@MyTag"` (see info about tags in the Writing Tests section).
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ You can kill the server with `npm run selenium-kill`
 ## Running Tests
 Once you have your environment variables configured and the Selenium server is running, you should be able to successfully run the tests.
 
-If you want to run `gen3-qa` against a dev environment, you just need to set the environment variable `NAMESPACE={dev env namespace}` and the `GOOGLE_APP_CREDS_JSON` to the credentials getting from Google, then run `./run-tests-localsh`
+If you want to run `gen3-qa` against a dev environment, you just need to set the environment variable `NAMESPACE={dev env namespace}` and the `GOOGLE_APP_CREDS_JSON` to the credentials getting from Google, then run `./run-tests-localsh`.
 
 But as mentioned above, some tests have special requirements so you may not want to run them. Instead, you can run a selection of tests that have certain tag by altering the line in `run-tests-local.sh` file `npm test -- --grep "@MyTag"` (see info about tags in the Writing Tests section).
+
+The special dev environment setup that is required by some tests is described [here](https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/gen3qa-dev-env.md).
 
 ## Writing Tests
 Each API or web page feature is contained in a singe .js file. They are stored in `suites/apis` and `suites/portal`, with filenames matching the pattern `*Test.js`.

--- a/helpers/cdisHelper.js
+++ b/helpers/cdisHelper.js
@@ -7,12 +7,6 @@ class CDISHelper extends Helper {
     const helper = this.helpers.WebDriverIO;
     // get the session id for the web driver
     global.seleniumSessionId = helper.browser.requestHandler.sessionID;
-    // if not doing an API test, set the access token cookie
-    if (!(suite.title.indexOf('API') >= 0)) {
-      helper.amOnPage('');
-      const accessToken = user.mainAcct.accessToken;
-      helper.setCookie({ name: 'access_token', value: accessToken });
-    }
   }
 
   async _failed(testResult) { // eslint-disable-line class-methods-use-this

--- a/services/portal/home/homeProps.js
+++ b/services/portal/home/homeProps.js
@@ -6,7 +6,7 @@ module.exports = {
 
   ready_cue: {
     locator: {
-      text: 'cdis.autotest@gmail.com',
+      css: '.nav-bar',
     },
   },
 
@@ -27,6 +27,12 @@ module.exports = {
   googleLoginButton: {
     locator: {
       xpath: '//button[contains(text(), \'Login from Google\')]',
+    },
+  },
+
+  logoutButton: {
+    locator: {
+      xpath: '//div[contains(text(), \'Logout\')]',
     },
   },
 };

--- a/services/portal/home/homeQuestions.js
+++ b/services/portal/home/homeQuestions.js
@@ -16,7 +16,11 @@ module.exports = {
     portal.seeProp(homeProps.cards, 5, 4);
   },
 
-  seeUserLoggedIn(userAcct) {
-    I.waitForText(userAcct.username, 5);
-  }
+  seeUserLoggedIn(username) {
+    I.waitForText(username, 5);
+  },
+
+  isLoggedOut() {
+    portal.seeProp(homeProps.googleLoginButton, 5);
+  },
 };

--- a/services/portal/home/homeSequences.js
+++ b/services/portal/home/homeSequences.js
@@ -8,7 +8,7 @@ const I = actor();
  * home sequences
  */
 module.exports = {
-  async login(userAcct = user.mainAcct) {
+  login(userAcct = user.mainAcct) {
     homeTasks.login(userAcct.username);
     homeQuestions.haveAccessToken();
     homeQuestions.seeUserLoggedIn(userAcct.username);

--- a/services/portal/home/homeSequences.js
+++ b/services/portal/home/homeSequences.js
@@ -2,13 +2,20 @@ const homeQuestions = require('./homeQuestions.js');
 const homeTasks = require('./homeTasks.js');
 const user = require('../../../utils/user.js');
 
+const I = actor();
+
 /**
  * home sequences
  */
 module.exports = {
   async login(userAcct = user.mainAcct) {
-    await homeTasks.login(userAcct);
+    homeTasks.login(userAcct.username);
     homeQuestions.haveAccessToken();
-    homeQuestions.seeUserLoggedIn(userAcct);
+    homeQuestions.seeUserLoggedIn(userAcct.username);
+  },
+
+  logout() {
+    homeTasks.logout();
+    homeQuestions.isLoggedOut();
   },
 };

--- a/services/portal/home/homeTasks.js
+++ b/services/portal/home/homeTasks.js
@@ -28,8 +28,5 @@ module.exports = {
    */
   logout() {
     portal.clickProp(homeProps.logoutButton);
-    I.saveScreenshot('after-logout1.png');
-    this.goToHomepage();
-    I.saveScreenshot('after-logout2.png');
   },
 };

--- a/services/portal/home/homeTasks.js
+++ b/services/portal/home/homeTasks.js
@@ -7,7 +7,7 @@ const I = actor();
  * home Tasks
  */
 module.exports = {
-  goTo() {
+  goToHomepage() {
     I.amOnPage(homeProps.path);
     portal.seeProp(homeProps.ready_cue, 10);
   },
@@ -15,10 +15,21 @@ module.exports = {
   /**
    * Logs into windmill. Uses the "dev_login" cookie to tell fence
    * which username to use when mocking the login.
+   * /!\ remember to logout after logging in or following tests will fail!
    */
-  async login(userAcct) {
-    await I.amOnPage('/');
-    I.setCookie({ name: 'dev_login', value: userAcct.username });
+  login(username) {
+    this.goToHomepage();
+    I.setCookie({ name: 'dev_login', value: username });
     portal.clickProp(homeProps.googleLoginButton);
-  }
+  },
+
+  /**
+   * Logs out of windmill
+   */
+  logout() {
+    portal.clickProp(homeProps.logoutButton);
+    I.saveScreenshot('after-logout1.png');
+    this.goToHomepage();
+    I.saveScreenshot('after-logout2.png');
+  },
 };

--- a/suites/portal/dataUploadTest.js
+++ b/suites/portal/dataUploadTest.js
@@ -58,8 +58,8 @@ BeforeSuite(async (sheepdog, nodes, users, fence, indexd) => {
   submitterID = newSubmitterID;
 });
 
-Before(async (home) => {
-  await home.complete.login();
+Before((home) => {
+  home.complete.login();
 });
 
 Scenario('Map uploaded files in windmill submission page @dataUpload', async (sheepdog, nodes, files, fence, users, indexd, portalDataUpload, dataUploadUtil) => {
@@ -89,6 +89,10 @@ Scenario('Cannot see files uploaded by other users @dataUpload', async(sheepdog,
 
   // user1 cannot see file2
   await portalDataUpload.complete.checkUnmappedFilesAreNotInFileMappingPage([fileObj]);
+});
+
+After((home) => {
+  home.complete.logout();
 });
 
 AfterSuite(async (sheepdog, indexd, files, dataUploadUtil) => {

--- a/suites/portal/homepageTest.js
+++ b/suites/portal/homepageTest.js
@@ -1,7 +1,8 @@
 Feature('Login');
 
 Scenario('login', async(home) => {
-  home.do.goTo();
-  await home.complete.login();
+  home.do.goToHomepage();
+  home.complete.login();
   home.ask.seeDetails();
+  home.complete.logout();
 });

--- a/suites/portal/homepageTest.js
+++ b/suites/portal/homepageTest.js
@@ -1,6 +1,6 @@
 Feature('Login');
 
-Scenario('login', async(home) => {
+Scenario('login', (home) => {
   home.do.goToHomepage();
   home.complete.login();
   home.ask.seeDetails();


### PR DESCRIPTION
Fixes a bug where a test logs in, doesn't log out, and the following tests fail because they don't find the login button
- do not set an `access_token` to log in at the beginning of the tests
- log in and log out using the portal buttons before and after each windmill test