### PR TITLE
fix(homepage-test)

### DIFF
--- a/services/portal/home/homeQuestions.js
+++ b/services/portal/home/homeQuestions.js
@@ -13,7 +13,7 @@ module.exports = {
 
   seeDetails() {
     portal.seeProp(homeProps.summary, 5, 1);
-    portal.seeProp(homeProps.cards, 5, 4);
+    portal.seeProp(homeProps.cards, 5);
   },
 
   seeUserLoggedIn(username) {


### PR DESCRIPTION
Checking that the homepage contains exactly 4 `.index-button-bar__thumbnail-button` elements (the boxes `Define Data Field`, `Access Data` etc) makes the tests fail on cdis-manifest PRs for commons that don't have exactly 4 boxes, for example CVB:

![cvb-test](https://user-images.githubusercontent.com/4224001/53371489-00620b80-3916-11e9-80b0-d7ca398f07cd.png)

Checking that at least 1 box is there should be enough to make sure the page has loaded