### PR TITLE
fix(pidgin-log)

### DIFF
--- a/services/apis/pidgin/pidginQuestions.js
+++ b/services/apis/pidgin/pidginQuestions.js
@@ -11,7 +11,15 @@ const pidginProps = require('./pidginProps.js');
 module.exports = {
   
   seeJsonCoremetadata(file, metadata) {
-    let data = JSON.parse(metadata);
+    let data;
+    try {
+      data = JSON.parse(metadata);
+    }
+    catch {
+      console.log(metadata);
+      throw new Error(`Unable to parse the data returned by Pidgin:\n${metadata}`);
+    }
+
     expect(data['file_name'], 'file_name not in core metadata').to.equal(file.data.file_name);
     expect(data['object_id'], 'object_id not in core metadata').to.equal(file.did);
     expect(data['type'], 'type not in core metadata').to.equal(file.data.type);
@@ -29,7 +37,7 @@ module.exports = {
   },
   
   // to be implemented to support application/vnd.schemaorg.ld+json format
-  // seeSchemaorgdata(file, metadata){
+  // seeSchemaorgCoremetadata(file, metadata){
   //   console.log(metadata)
   // },
 

--- a/suites/apis/getCoremetadataTest.js
+++ b/suites/apis/getCoremetadataTest.js
@@ -13,7 +13,7 @@ Scenario('test core metadata', async(pidgin, users) => {
 
   // to be implemented to support application/vnd.schemaorg.ld+json format in future
   // metadata = await pidgin.do.getCoremetadata(valid_file, 'application/vnd.schemaorg.ld+json', users.mainAcct.accessTokenHeader);
-  // pidgin.ask.seeSchemaorgdata(valid_file, metadata);
+  // pidgin.ask.seeSchemaorgCoremetadata(valid_file, metadata);
 });
 
 Scenario('test core metadata invalid object_id', async(pidgin, users) => {


### PR DESCRIPTION
Peregrine version earlier than 1.0.8 makes pidgin fail - add an error log to the pidgin test to help catch it and debug