### PR TITLE
Feat/hostname param

### DIFF
--- a/run-performance-tests.sh
+++ b/run-performance-tests.sh
@@ -78,7 +78,6 @@ echo 'INFO: installing dependencies'
 dryrun npm ci
 
 exitCode=0
-lockUser=""
 
 testArgs="--debug --verbose --reporter mocha-multi"
 
@@ -116,13 +115,5 @@ EOM
   )
   if [[ $? -ne 0 ]]; then exitCode=1; fi
 done
-
-if [[ -n "$lockUser" ]]; then
-  (
-    # release the dcf lock
-    export KUBECTL_NAMESPACE=default
-    dryrun gen3 klock unlock dcftest "$lockUser"
-  )
-fi
 
 exit $exitCode

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -130,7 +130,6 @@ echo 'INFO: installing dependencies'
 dryrun npm ci
 
 exitCode=0
-lockUser=""
 
 
 # hostnames that use DCF features
@@ -150,7 +149,6 @@ else
   # Run tests including dcf google backend
   # Acquire google test lock - only one test can interact with the GCP test project
   #
-  lockUser="testRunner-${namespaceName}-$$"
   echo "INFO: enabling Google Data Access tests for $service"
 fi
 
@@ -177,13 +175,5 @@ Launching test in $NAMESPACE
 EOM
   dryrun npm test -- $testArgs
 ) || exitCode=1
-
-if [[ -n "$lockUser" ]]; then
-  (
-    # release the dcf lock
-    export KUBECTL_NAMESPACE=default
-    dryrun gen3 klock unlock dcftest "$lockUser"
-  )
-fi
 
 exit $exitCode

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 #
 # Jenkins launch script.
 # Use:
-#   bash run-tests.sh 'namespace1 namespace2 ...' [--service=fence]
+#   bash run-tests.sh 'namespace1 namespace2 ...' [--service=fence] [--hostname=hostname]
 #
 
 help() {
@@ -14,7 +14,7 @@ Use:
   bash run-tests.sh [[--namespace=]KUBECTL_NAMESPACE] [--service=service] [--hostname=hostname] [--dryrun]
     --namespace default is KUBECTL_NAMESPACE:-default
     --service default is service:-none
-    --hostname default is hostname:-none
+    --hostname default is hostname:-none (for cdis-manifest PRs, specifies which environment is being tested, to know which tests are relevant)
 EOM
 }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,9 +11,10 @@ Jenkins test launch script.  Assumes the  GEN3_HOME environment variable
 references a current [cloud-automation](https://github.com/uc-cdis/cloud-automation) folder.
 
 Use:
-  bash run-tests.sh [[--namespace=]KUBECTL_NAMESPACE] [--service=service] [--dryrun]
+  bash run-tests.sh [[--namespace=]KUBECTL_NAMESPACE] [--service=service] [--hostname=hostname] [--dryrun]
     --namespace default is KUBECTL_NAMESPACE:-default
     --service default is service:-none
+    --hostname default is hostname:-none
 EOM
 }
 
@@ -66,6 +67,7 @@ gen3_load "gen3/gen3setup"
 
 namespaceName="${KUBECTL_NAMESPACE}"
 service="${service:-""}"
+hostname="${hostname:-""}"
 
 while [[ $# -gt 0 ]]; do
   key="$(echo "$1" | sed -e 's/^-*//' | sed -e 's/=.*$//')"
@@ -80,6 +82,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     namespace)
       namespaceName="$value"
+      ;;
+    hostname)
+      hostname="$value"
       ;;
     dryrun)
       isDryRun=true
@@ -128,13 +133,17 @@ exitCode=0
 lockUser=""
 
 
+# hostnames that use DCF features
+# we will run Google Data Access tests for cdis-manifest PRs to these
+requireGoogleHostnames="dcp.bionimbus.org gen3.datastage.io nci-crdc-demo.datacommons.io nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+
 #
-# DCF Google tests are not yet stable enough to run in all PR's -
+# Google Data Access tests are not yet stable enough to run in all PR's -
 # so just enable in PR's for some projects now
 #
-if [[ "$service" != "gen3-qa" && "$service" != "fence" && "$service" != "cdis-manifest" ]]; then
+if [[ "$service" != "gen3-qa" && "$service" != "fence" && !("$service" == "cdis-manifest" && $requireGoogleHostnames =~ (^| )$hostname($| )) ]]; then
   # run all tests except for those that require dcf google configuration
-  echo "INFO: disabling DCF tests for $service"
+  echo "INFO: disabling Google Data Access tests for $service"
   donot '@reqGoogle'
 else
   #
@@ -142,30 +151,7 @@ else
   # Acquire google test lock - only one test can interact with the GCP test project
   #
   lockUser="testRunner-${namespaceName}-$$"
-  echo "INFO: enabling DCF tests for $service"
-  (
-    #
-    # acquire the freakin' global DCF lock
-    # all of our test environment's share the same
-    # backend DCF google project and CloudIdentity,
-    # so only want one DCF test running globally at a time
-    #
-    export KUBECTL_NAMESPACE=default
-    count=0
-    gotLock=false
-    while [[ $count -lt 10 && $gotLock == false ]]; do
-      echo 'INFO: waiting to lock the DCF test google project'
-      if dryrun gen3 klock lock dcftest "$lockUser" 300 -w 60; then
-        gotLock=true
-      fi
-    done
-    if [[ $gotLock == true ]]; then
-      echo "Acquired the DCF lock"
-    else
-      echo "Failed to acquire the DCF lock after 10 minutes - bailing out"
-      exit 1
-    fi
-  ) || exit 1
+  echo "INFO: enabling Google Data Access tests for $service"
 fi
 
 


### PR DESCRIPTION
Only run the Google tests on cdis-manifest PRs if the changes are for a commons that uses DCF features (PXP-2758)

- add hostname parameter to run-tests.sh
- remove the DCF lock since we are implementing another lock (https://github.com/uc-cdis/gen3-qa/pull/97)