### PR TITLE
chore(bool-filter): remove boolean filter test

### DIFF
--- a/suites/apis/submitAndQueryNodesTest.js
+++ b/suites/apis/submitAndQueryNodesTest.js
@@ -96,30 +96,6 @@ Scenario('filter query by string attribute @reqData', async (sheepdog, peregrine
   await sheepdog.complete.deleteNodes(nodes.getPathToFile());
 });
 
-// FIXME: This is a known bug that needs to be fixed. See PXP-1570
-Scenario('filter query by boolean attribute @reqData', async (peregrine) => {
-  // This test assumes that projects in all commons will have a boolean attribute 'releasable'
-  const booleanState = Commons.project.releasable;
-  const q = `
-  {
-   project(releasable: ${booleanState}) {
-    id
-   }
-  }
-  `;
-  const res = await peregrine.do.query(q, null);
-  // TODO: remove try/catch once bug is fixed
-  try {
-    peregrine.ask.hasFieldCount(res, 'project', 1);
-  } catch (e) {
-    console.log(
-      `WARNING: test graphQL filter by boolean attribute is FAILING (See PXP-1570): ${
-        e.message
-      }`,
-    );
-  }
-});
-
 Scenario('test _[field]_count filter @reqData', async (peregrine, sheepdog, nodes) => {
   // Count number of each node type
   const previousCounts = {};
@@ -172,7 +148,7 @@ Scenario('filter by invalid project_id @reqData', async (peregrine, sheepdog, no
   await sheepdog.do.deleteNode(nodes.getFirstNode());
 });
 
-
+// FIXME: This is a known bug that needs to be fixed. See PXP-1569
 Scenario('test with_path_to - first to last node @reqData', async (peregrine, sheepdog, nodes) => {
   await sheepdog.complete.addNodes(nodes.getPathToFile());
 


### PR DESCRIPTION
This was fixed in https://github.com/uc-cdis/peregrine/pull/124

I think removing this test from here is our best option:
- if we re-enable it, integration tests for cdis-manifest PRs on commons that are not using the latest version of peregrine will fail
- it's basically a copy of the unit test i'm adding to peregrine, it's not really an integration test, it adds no coverage