### PR TITLE
Chore/python3

### DIFF
--- a/services/apis/fence/fenceProps.js
+++ b/services/apis/fence/fenceProps.js
@@ -138,9 +138,9 @@ module.exports = {
     statusCode: 404,
   }),
 
-  resUserAlreadyLinked: 'error_description=User+already+has+a+linked+Google+account.&error=g_acnt_link_error',
+  resUserAlreadyLinked: 'error_description=User+already+has+a+linked+Google+account.',
 
-  resAccountAlreadyLinked: 'error_description=Could+not+link+Google+account.+The+account+specified+is+already+linked+to+a+different+user.&error=g_acnt_link_error',
+  resAccountAlreadyLinked: 'error_description=Could+not+link+Google+account.+The+account+specified+is+already+linked+to+a+different+user.',
 
   /**
    * Consent page

--- a/services/apis/fence/fenceQuestions.js
+++ b/services/apis/fence/fenceQuestions.js
@@ -209,7 +209,7 @@ module.exports = {
   assertUserInfo(response) {
     expect(
       response,
-      'response from userinfo endpoint does not have property: statusCode'
+      'response from userinfo endpoint should have property statusCode of 200'
     ).to.have.property('statusCode', 200);
     expect(
       response,

--- a/services/apis/fence/fenceTasks.js
+++ b/services/apis/fence/fenceTasks.js
@@ -242,7 +242,7 @@ module.exports = {
     return I.sendGetRequest(url, headers).then(async (res) => {
 
       // if no error, follow redirect back to fence
-      if (!res.headers.location.includes("error=")) {
+      if (res.headers.location && !res.headers.location.includes("error=")) {
         let sessionCookie = getCookie('fence', res.headers['set-cookie']);
         headers.Cookie += `; fence=${sessionCookie}`;
         res = await I.sendGetRequest(res.headers.location, headers);

--- a/suites/apis/OAuth2Test.js
+++ b/suites/apis/OAuth2Test.js
@@ -217,7 +217,7 @@ Scenario('Implicit flow: Test that fails to generate tokens due to openid scope 
 Scenario('Implicit flow: Test that can create an access token which can be used in fence', async (fence) => {
   const resULR = await fence.do.getTokensImplicitFlow(
     fence.props.clients.clientImplicit.id, 'id_token+token', 'openid+user');
-  const match = resULR.match(RegExp('access_token=(.*)&expires'));
+  const match = resULR.match(RegExp('access_token=(.*)'));
   const token = match && match[1];
   fence.ask.assertTruthyResult(
     token,

--- a/suites/apis/OAuth2Test.js
+++ b/suites/apis/OAuth2Test.js
@@ -218,7 +218,8 @@ Scenario('Implicit flow: Test that can create an access token which can be used 
   const resULR = await fence.do.getTokensImplicitFlow(
     fence.props.clients.clientImplicit.id, 'id_token+token', 'openid+user');
   const match = resULR.match(RegExp('access_token=(.*)'));
-  const token = match && match[1];
+  let token = match && match[1];
+  token = token.split('&')[0] // remove other query parameters
   fence.ask.assertTruthyResult(
     token,
     `fence\'s oauth2/authorize endpoint in implicit flow should have returned an access token in url "${resULR}"`


### PR DESCRIPTION
query parameters in URLs are not sorted in the same order in py3 as in py2: fix tests that rely on param order

also fix unrelated bug in function `linkGoogleAcctMocked`