### PR TITLE
update hostname

### DIFF
--- a/utils/commanders/sshk8s.js
+++ b/utils/commanders/sshk8s.js
@@ -24,11 +24,11 @@ class SshK8s extends Base {
     const namespace = process.env.NAMESPACE;
     const commonsUser = userFromNamespace(namespace);
     if (service === undefined) {
-      return cleanResult(execSync(`ssh ${commonsUser}@cdistest.csoc 'set -i; source ~/.bashrc; ${cmd}'`,
+      return cleanResult(execSync(`ssh ${commonsUser}@cdistest_dev.csoc 'set -i; source ~/.bashrc; ${cmd}'`,
         { shell: '/bin/bash' }).toString('utf8'));
     } else {
       return cleanResult(execSync(
-        `ssh ${commonsUser}@cdistest.csoc 'set -i; source ~/.bashrc; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
+        `ssh ${commonsUser}@cdistest_dev.csoc 'set -i; source ~/.bashrc; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
         { shell: '/bin/sh' }
       ).toString('utf8'));
     }


### PR DESCRIPTION
https://github.com/uc-cdis/cdis-wiki/blob/e044321fa3ebabc14dcef8a4af7b6842188d7a38/ops/AWS-Accounts.md#L80 

Old cdistest ip has been deprecated; our template ssh config changed; just changing this to match.

### Improvements
Update deprecated ssh hostname
