### PR TITLE
fix(multipart)

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -184,6 +184,7 @@ dryrun npm ci
 ################################ Disable Test Tags #####################################
 
 runTestsIfServiceVersion "@multipartUpload" "fence" "2.8.0"
+runTestsIfServiceVersion "@multipartUploadFailure" "fence" "3.0.0"
 runTestsIfServiceVersion "@centralizedAuth" "fence" "3.0.0"
 runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 

--- a/suites/apis/dataUploadTest.js
+++ b/suites/apis/dataUploadTest.js
@@ -329,7 +329,7 @@ Scenario('Successful multipart upload @dataUpload @multipartUpload', async (user
  * Use fence's multipart upload endpoints to upload a large data file (>5MB).
  * Fail to complete the upload because of a wrong ETag input
  */
-Scenario('Failed multipart upload: wrong ETag for completion @dataUpload @multipartUpload', async (users, fence, dataUpload) => {
+Scenario('Failed multipart upload: wrong ETag for completion @dataUpload @multipartUpload @multipartUploadFailure', async (users, fence, dataUpload) => {
   // initialize the multipart upload
   console.log("Initializing multipart upload");
   const accessHeader = users.mainAcct.accessTokenHeader;


### PR DESCRIPTION
The multipart upload feature is in fence 2.8.2 but there is a fix to the error handling that is in fence 3.0.0. So in 2.8.2, the feature works but if the multipart upload fails, the user will see 500 instead of the expected error code. So the integration test `Data file upload flow - Failed multipart upload: wrong ETag for completion` fails.

Fence 3.0.0 can only be deployed at the same time as the other centralized auth updates, so commons that need the multipart upload but not the centralized auth use fence 2.8.2.

=> disable the failing test for fence < 3.0.0