### PR TITLE
fix(login)

### DIFF
--- a/services/portal/home/homeProps.js
+++ b/services/portal/home/homeProps.js
@@ -14,7 +14,7 @@ module.exports = {
 
   summary: {
     locator: {
-      css: '.h1-typo',
+      css: '.introduction',
     },
   },
 


### PR DESCRIPTION
The login test looks for a `h1-typo` element which is **not** displayed on the portal when `components.index.introduction.heading` is set to `""` in the portal config, which is the case for some commons
=> look for `introduction` element instead