### PR TITLE
fix(auth-error): handle both pre- and post-arborist

### DIFF
--- a/services/apis/sheepdog/sheepdogProps.js
+++ b/services/apis/sheepdog/sheepdogProps.js
@@ -62,12 +62,12 @@ module.exports = {
   /**
    * Expected contents of the response when no authentication is provided
    */
-  resNoAuth: {
+  resExpiredAuth: {
     status: 401,
     // Before sheepdog's arborist update, the error is:
     // "Authentication Error: Signature has expired"
     // After sheepdog's arborist update, the error is:
-    // "request to arborist failed: error decoding token: expired at time: 1567720295"
+    // "request to arborist failed: error decoding token: expired at time: 123456"
     errorMsg: 'expired',
   },
 

--- a/services/apis/sheepdog/sheepdogProps.js
+++ b/services/apis/sheepdog/sheepdogProps.js
@@ -60,13 +60,16 @@ module.exports = {
   }),
 
   /**
-   * Gen3Response when no authentication provided
+   * Expected contents of the response when no authentication is provided
    */
-  resNoAuth: new Gen3Response({
-    request: {},
+  resNoAuth: {
     status: 401,
-    body: { message: 'Authentication Error: Signature has expired' },
-  }),
+    // Before sheepdog's arborist update, the error is:
+    // "Authentication Error: Signature has expired"
+    // After sheepdog's arborist update, the error is:
+    // "request to arborist failed: error decoding token: expired at time: 1567720295"
+    errorMsg: 'expired',
+  },
 
   resLocators: {
     entityErrorType: 'data.entities[0].errors[0].type',

--- a/services/apis/sheepdog/sheepdogQuestions.js
+++ b/services/apis/sheepdog/sheepdogQuestions.js
@@ -93,6 +93,11 @@ module.exports = {
    * @param {Gen3Response} res
    */
   hasNoAuthError(res) {
-    expect(res).to.be.a.gen3Res(sheepdogProps.resNoAuth);
+    expect(res).to.be.a.gen3Res;
+    expect(res.status).to.equal(sheepdogProps.resNoAuth.status);
+    // Before sheepdog's arborist update, the error is in body.message
+    // After sheepdog's arborist update, the error is in body.error
+    const msg = res.body.error || res.body.message;
+    expect(msg).to.contain(sheepdogProps.resNoAuth.errorMsg);
   },
 };

--- a/services/apis/sheepdog/sheepdogQuestions.js
+++ b/services/apis/sheepdog/sheepdogQuestions.js
@@ -92,12 +92,12 @@ module.exports = {
    * Asserts a sheepdog response has error due to missing authentication
    * @param {Gen3Response} res
    */
-  hasNoAuthError(res) {
+  hasExpiredAuthError(res) {
     expect(res).to.be.a.gen3Res;
-    expect(res.status).to.equal(sheepdogProps.resNoAuth.status);
+    expect(res.status).to.equal(sheepdogProps.resExpiredAuth.status);
     // Before sheepdog's arborist update, the error is in body.message
     // After sheepdog's arborist update, the error is in body.error
     const msg = res.body.error || res.body.message;
-    expect(msg).to.contain(sheepdogProps.resNoAuth.errorMsg);
+    expect(msg).to.contain(sheepdogProps.resExpiredAuth.errorMsg);
   },
 };

--- a/suites/apis/submitAndQueryNodesTest.js
+++ b/suites/apis/submitAndQueryNodesTest.js
@@ -4,7 +4,7 @@ Feature('SubmitAndQueryNodesTest');
 
 Scenario('submit node unauthenticated @reqData', async (sheepdog, nodes, users) => {
   await sheepdog.do.addNode(nodes.getFirstNode(), users.mainAcct.expiredAccessTokenHeader);
-  sheepdog.ask.hasNoAuthError(nodes.getFirstNode().addRes);
+  sheepdog.ask.hasExpiredAuthError(nodes.getFirstNode().addRes);
   await sheepdog.do.deleteNode(nodes.getFirstNode());
 }).retry(2);
 


### PR DESCRIPTION
Before sheepdog's integration with arborist, the error is "Authentication Error: Signature has expired" and it's in body.message
After, the error is "request to arborist failed: error decoding token: expired at time: 1567720295" and it's in body.error
This works for both cases