### PR TITLE
chore(getAccessTokenInJS): Adding a js util script to fetch access tokens

### DIFF
--- a/getAccessToken.js
+++ b/getAccessToken.js
@@ -11,5 +11,5 @@ getAccessTokenFromApiKey(API_KEY, TARGET_ENVIRONMENT)
     .then((ACCESS_TOKEN) => {
 	console.log(ACCESS_TOKEN);
     }).catch((reason) => {
-	console.log('Failed: ' + reason.status +' - ' + reason.statusText);
+	console.log(`Failed: ${reason.status} - ${reason.statusText}`);
     });

--- a/getAccessToken.js
+++ b/getAccessToken.js
@@ -1,0 +1,14 @@
+const { getAccessTokenFromApiKey } = require('./utils/apiUtil');
+
+TARGET_ENVIRONMENT = process.env.GEN3_COMMONS_HOSTNAME;
+// console.log('target environment: ' + TARGET_ENVIRONMENT);
+API_KEY = process.env.API_KEY;
+// console.log('api key: ' + API_KEY);
+
+// obtain access token through fence API
+getAccessTokenFromApiKey(API_KEY, TARGET_ENVIRONMENT)
+    .then((ACCESS_TOKEN) => {
+	console.log('access_token: ' + ACCESS_TOKEN);
+    }).catch((reason) => {
+	console.log('Failed: ' + reason.status +' - ' + reason.statusText);
+    });

--- a/getAccessToken.js
+++ b/getAccessToken.js
@@ -1,5 +1,6 @@
 const { getAccessTokenFromApiKey } = require('./utils/apiUtil');
 
+// The following environment variables are set by 'getAccessToken.sh'
 TARGET_ENVIRONMENT = process.env.GEN3_COMMONS_HOSTNAME;
 // console.log('target environment: ' + TARGET_ENVIRONMENT);
 API_KEY = process.env.API_KEY;
@@ -8,7 +9,7 @@ API_KEY = process.env.API_KEY;
 // obtain access token through fence API
 getAccessTokenFromApiKey(API_KEY, TARGET_ENVIRONMENT)
     .then((ACCESS_TOKEN) => {
-	console.log('access_token: ' + ACCESS_TOKEN);
+	console.log(ACCESS_TOKEN);
     }).catch((reason) => {
 	console.log('Failed: ' + reason.status +' - ' + reason.statusText);
     });

--- a/utils/env.js
+++ b/utils/env.js
@@ -6,9 +6,8 @@
 const ENV_TYPE = { JENKINS: 0, LOCAL_AGAINST_GEN3_K8S: 1, LOCAL_AGAINST_DOCKER: 2, LOCAL_AGAINST_REMOTE: 3 };
 
 function getEnvType(){
-  console.error('getEnvType');
-  console.error(process.env.NAMESPACE);
-  console.error(process.env.RUNNING_LOCAL);
+  if (process.env.NAMESPACE) console.error(process.env.NAMESPACE);
+  if (process.env.RUNNING_LOCAL) console.error(process.env.RUNNING_LOCAL);
   if (process.env.JENKINS_HOME !== '' && process.env.JENKINS_HOME !== undefined) {
     return ENV_TYPE.JENKINS;
   } else if (process.env.GEN3_COMMONS_HOSTNAME) {


### PR DESCRIPTION
Tweaking the existing `getAccessToken.sh` script to call a new script: `getAccessToken.js`.
This new script invokes a new lib function: `getAccessTokenFromApiKey ` (which will also be used by executable tests).

Test run:
```
% /bin/bash getAccessToken.sh ~/.gen3/credentials.json
...
access_token: eyJ0eX***
```