### PR TITLE
chore(DCFTests): Tweak lib to support svc acct registration dry run and Google monitor tests

### DIFF
--- a/services/apis/fence/fenceProps.js
+++ b/services/apis/fence/fenceProps.js
@@ -92,6 +92,7 @@ module.exports = {
     registerGoogleServiceAccount: `${rootEndpoint}/google/service_accounts`,
     deleteGoogleServiceAccount: `${rootEndpoint}/google/service_accounts`,
     getGoogleServiceAccounts: `${rootEndpoint}/google/service_accounts`,
+    getGoogleSvcAcctMonitor: `${rootEndpoint}/google/service_accounts/monitor`,
     authorizeOAuth2Client: `${rootEndpoint}/oauth2/authorize`,
     tokenOAuth2Client: `${rootEndpoint}/oauth2/token`,
     userEndPoint: `${rootEndpoint}/user`,

--- a/services/apis/fence/fenceTasks.js
+++ b/services/apis/fence/fenceTasks.js
@@ -376,7 +376,7 @@ module.exports = {
   },
 
   /**
-   * Updates a google service account
+   * Updates a Google service account
    * @param {User} userAcct - User to make request with
    * @param {string} serviceAccountEmail - email of service account to update
    * @param {string[]} projectAccessList - list of project names to set for service account's access

--- a/services/apis/fence/fenceTasks.js
+++ b/services/apis/fence/fenceTasks.js
@@ -294,8 +294,9 @@ module.exports = {
    * @param {int} expires_in - requested expiration time (in seconds)
    * @returns {Promise<Gen3Response>}
    */
-  async registerGoogleServiceAccount(userAcct, googleProject, projectAccessList, expires_in=null) {
+    async registerGoogleServiceAccount(userAcct, googleProject, projectAccessList, expires_in=null, is_dry_run=false) {
     url = fenceProps.endpoints.registerGoogleServiceAccount;
+    if (is_dry_run) url += '/_dry_run';
     if (expires_in) {
       url += `?expires_in=${expires_in}`;
     }
@@ -387,6 +388,18 @@ module.exports = {
       {
         project_access: projectAccessList,
       },
+      userAcct.accessTokenHeader,
+    ).then(res => new Gen3Response(res));
+  },
+
+  /**
+   * Gets the ID of the monitor account (fence-service account)
+   * @param {User} userAcct - User to make request with
+   * @returns {Promise<Gen3Response>}
+   */
+  async getGoogleSvcAcctMonitor(userAcct) {
+    return I.sendGetRequest(
+      fenceProps.endpoints.getGoogleSvcAcctMonitor,
       userAcct.accessTokenHeader,
     ).then(res => new Gen3Response(res));
   },


### PR DESCRIPTION
Small changes to the core gen3-qa lib to support a couple of DCF Staging test scenarios.

I've tested these changes with the following verification script:
https://gist.github.com/themarcelor/1d976784bb29c15d621f0dd61a4cddf2

The test was successful.
Placing this in a small PR to monitor the results of the fully-automated / integration tests executed against other PRs.