### PR TITLE
task(dcf): Executable tests for DCF: linking Google account scenarios

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -93,7 +93,7 @@ exports.config = {
   },
   bootstrap: './test_setup.js',
   hooks: [],
-  tests: './suites/*/*.js',
+  tests: './suites/**/*.js',
   timeout: 60000,
   name: 'selenium',
 };

--- a/suites/pre-release/dcf/1.linkAccountsTest.js
+++ b/suites/pre-release/dcf/1.linkAccountsTest.js
@@ -1,0 +1,107 @@
+// Feature # 1 in the sequence of testing
+// This test plan has a few pre-requisites: Check prereq.md for more details.
+Feature('1. Linking accounts - DCF Staging testing for release sign off - https://ctds-planx.atlassian.net/browse/PXP-3836');
+
+// To be executed with GEN3_SKIP_PROJ_SETUP=true -- No need to set up program / retrieve access token, etc.
+
+const fenceProps = require('../../../services/apis/fence/fenceProps.js');
+const user = require('../../../utils/user.js');
+const chai = require('chai');
+const {interactive, ifInteractive} = require('../../../utils/interactive.js');
+const { Gen3Response, getAccessTokenFromExecutableTest, getAccessTokenHeader } = require('../../../utils/apiUtil');
+const expect = chai.expect;
+
+// Test elaborated for nci-crdc but it can be reused in other projects
+const TARGET_ENVIRONMENT = process.env.GEN3_COMMONS_HOSTNAME || 'nci-crdc-staging.datacommons.io';
+
+function linkGoogleAccount() {
+    Scenario(`Link Google identity to the NIH user @manual`, ifInteractive(
+	async(I, fence) => {
+	    const result = await interactive (`
+              1. Navigate to https://${TARGET_ENVIRONMENT}${fenceProps.endpoints.linkGoogle}
+              2. Provide the credentials of the Google account that owns the "Customer" GCP account
+                 This Google account will be linked to the NIH account within this Gen3 environment.
+            `);
+	    expect(result.didPass, result.details).to.be.true;
+	}
+    ));
+}
+
+function performAdjustExpDateTest(type_of_test) {
+    Scenario(`Adjust the expiration date of the Google account that has been linked @manual`, ifInteractive(
+	async(I, fence) => {
+	    let ACCESS_TOKEN = await getAccessTokenFromExecutableTest(I);
+	    console.log('access token: ' + ACCESS_TOKEN);
+
+	    // Arbitrarily setting linked Google account to expire in 2 hours
+	    const expiration_date_in_secs = 7200;
+
+	    // set a userAcct obj {} with an "accessTokenHeader" property to use Gen3-qa's Fence testing API
+            const http_resp = await fence.do.extendGoogleLink(
+		{ accessTokenHeader: getAccessTokenHeader(ACCESS_TOKEN) },
+		expiration_date_in_secs);
+
+	    let {expected_status, expected_response} = type_of_test == 'positive' ?
+		{ expected_status: 200, expected_response: 'new "exp" date (should express <current time + 2hs>)'} :
+		{ expected_status: 404, expected_response: '"User does not have a linked Google account." message'};
+
+	    const result = await interactive (`
+              1. [Automated] Send a HTTP PATCH request with the NIH user's ACCESS TOKEN to adjust the expiration date of a Google account (?expires_in=<current epoch time + 2 hours>):
+              HTTP PATCH request to: https://${TARGET_ENVIRONMENT}${fenceProps.endpoints.extendGoogleLink}\?expires_in\=${expiration_date_in_secs}
+              Manual verification:
+                Response status: ${http_resp.status} // Expect a HTTP ${expected_status}
+                Response data: ${JSON.stringify(http_resp.body) || http_resp.parsedFenceError} // Expect response containing the ${expected_response}
+              Converting epoch to timestamp: ${http_resp.status == 200 ? new Date(new Date(0).setUTCSeconds(http_resp.body['exp'])).toLocaleString() : 'cannot convert invalid response'}
+            `);
+	    expect(result.didPass, result.details).to.be.true;
+	}
+    ));
+}
+
+BeforeSuite(async(I) => {
+    console.log('Setting up dependencies...');
+    I.TARGET_ENVIRONMENT = TARGET_ENVIRONMENT;
+});
+
+// Scenario #1 - Verifying NIH access and permissions (project access)
+Scenario(`Login to https://${TARGET_ENVIRONMENT} and check the Project Access list under the Profile page @manual`, ifInteractive(
+    async(I) => {
+	const result = await interactive (`
+              1. Go to https://${TARGET_ENVIRONMENT}
+              2. Login with NIH account
+              3. Check if the Profile page contains projects the user can access
+              e.g., The projects are usually named as "phs000178".
+            `);
+	expect(result.didPass, result.details).to.be.true;
+    }
+));
+
+// Scenario #2 - Link Google account from the "customer" GCP account to the NIH user
+linkGoogleAccount();
+
+// Scenario #3 - Set expiration date for the linked Google Account
+performAdjustExpDateTest('positive');
+
+// Scenario #4 - Unlink Google account from the "customer" GCP account so it will be no longer associated with the NIH user
+Scenario(`Unlink Google identity from the NIH user @manual`, ifInteractive(
+    async(I, fence) => {
+	let ACCESS_TOKEN = await getAccessTokenFromExecutableTest(I);
+	console.log('access token: ' + ACCESS_TOKEN);
+
+	const http_resp = await fence.do.unlinkGoogleAcct({ accessTokenHeader: getAccessTokenHeader(ACCESS_TOKEN) });
+
+	const result = await interactive (`
+              1. [Automated] Send a HTTP DELETE request with the NIH user's ACCESS TOKEN to unlink the Google account:
+              HTTP DELETE request to: https://${TARGET_ENVIRONMENT}${fenceProps.endpoints.deleteGoogleLink}
+              Manual verification:
+                Response status: ${http_resp.status} // Expect a HTTP 200
+                Response data: ${JSON.stringify(http_resp.body) || http_resp.parsedFenceError} // Expect "undefined"
+            `);
+	expect(result.didPass, result.details).to.be.true;
+    }
+));
+
+performAdjustExpDateTest('negative');
+
+// Scenario #5 - Link Google account with the NIH user again to support the next features in the sequence
+linkGoogleAccount();

--- a/suites/pre-release/dcf/prereq.md
+++ b/suites/pre-release/dcf/prereq.md
@@ -1,0 +1,10 @@
+pre-requisites:
+-- 
+1. Google (`<user>@uchicago.edu` entry in users.yaml) & NIH access to the environment.
+2. Google Cloud Platform (GCP) account (outside the PlanX Org, i.e., simulating a customer account).
+3. An _outsider_ Google account that owns the _customer_ GCP account.
+4. A `fence-service` account must be added as _editor_ to IAM (with permissions to scan accounts).
+5. A New _customer_ service account must be created so it can be linked as part of the test flow.
+6. Existing files (successfully uploaded and indexed). A portion of these files must have a proper ACL configuration for both Google & NIH accounts, some files need to have an ACL versus Project Access mismatch to test _Access Denied_ scenarios.
+7. Client ID provided by developers (required for OIDC bootstrapping).
+8. Client Secret provided by developers (Used for basic auth to obtain tokens and to refresh the access token).


### PR DESCRIPTION
First set of executable tests for DCF.

List of DCF Staging test scenarios (as per https://github.com/uc-cdis/cdis-wiki/blob/master/qa/reports/2019/11/DcfStaging-20191114.md):

**--> 1. Bootstrapping accounts (linking Google account)**
2. User Managed Service Accounts
3. Google Credentials
4. Signed URLs
5. OAuth2/OIDC-flow/Client-Testing
6. Indexd 