### PR TITLE
chore(reporting): Enabling allure to capture output for local executable tests

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -94,6 +94,9 @@ exports.config = {
   bootstrap: './test_setup.js',
   hooks: [],
   tests: './suites/*/*.js',
+  plugins: {
+    "allure": {}
+  },
   timeout: 60000,
   name: 'selenium',
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "selenium-start": "selenium-standalone start > /dev/null 2>&1 &",
     "selenium-kill": "pkill -f selenium-standalone",
     "eslint": "eslint --ignore-path .gitignore .",
-    "test": "codeceptjs run",
+    "test": "codeceptjs run --plugins allure",
     "grep-test": ". local_run.sh && codeceptjs run --verbose --grep",
     "create-service": "node scripts/create_service.js"
   }


### PR DESCRIPTION
With this configuration in place, a command like this one:
```
% GEN3_SKIP_PROJ_SETUP=true RUNNING_LOCAL=true GEN3_COMMONS_HOSTNAME=gen3.datastage.io npm test -- --verbose --grep '@dataClientCLI|@reqGoogle' --invert suites/apis/dataStageOIDCFlowTest.js
```
Generates a new file under the `output` folder:
e.g., `output/6c4bce71-49ae-44e4-b3e6-d0d9f3d08eaa-testsuite.xml`

Containing all results from all the scenarios that have been tested.

To see the results in a Web GUI just run:

```
gen3-qa [test_allure] % allure serve output/6c4bce71-49ae-44e4-b3e6-d0d9f3d08eaa-testsuite.xml
Generating report to temp directory...
Report successfully generated to /var/folders/d8/qbg4jp1n3b1csgfdlql4qjlr0000gn/T/4941358701907850194/allure-report
Starting web server...
..
Server started at <http://10.151.6.63:61852/>
```