### PR TITLE
chore(logging): Move logging line to keep it within its test scenario

### DIFF
--- a/suites/apis/dataStageOIDCFlowTest.js
+++ b/suites/apis/dataStageOIDCFlowTest.js
@@ -221,11 +221,10 @@ performPreSignedURLTest("AWS S3", "positive", "Google");
 /* Scenarios with NIH account   */
 /* ############################### */
 
-console.log('Click on the logout button so you can log back in with your NIH account.');
-
 // Scenario #7 - Starting the OIDC flow again with NIH credentials
 Scenario('Initiate the OIDC Client flow with NIH credentials to obtain the OAuth authorization code @manual', ifInteractive(
     async(I) => {
+	console.log('Click on the logout button so you can log back in with your NIH account.');
 	// reset access token
 	delete I.cache.ACCESS_TOKEN;
         const result = await interactive (printOIDCFlowInstructions(I, "NIH"));


### PR DESCRIPTION
CodeceptJS runs this line even before the suites/apis/dataStageOIDCFlowTest.js Feature+Scenarios are executed, which leads to some misleading analysis while debugging some test failure.