### PR TITLE
chore(debug): Improve debugging / logging to investigate flaky tests

### DIFF
--- a/suites/google/googleServiceAccountKeyTest.js
+++ b/suites/google/googleServiceAccountKeyTest.js
@@ -47,7 +47,7 @@ After(async (google, fence, users) => {
   await fence.complete.suiteCleanup(google, users);
 });
 
-Scenario('Get current SA creds @reqGoogle', async (fence, users) => {
+Scenario('Get current SA creds @reqGoogle @disabled', async (fence, users) => {
   const EXPIRES_IN = 5;
 
   // Make sure there are no creds for this user
@@ -233,7 +233,7 @@ Scenario('SA key removal job test: remove expired creds @reqGoogle', async (fenc
 
   // Run the expired SA key clean up job
   console.log('Clean up expired Service Account keys');
-  bash.runJob('google-manage-keys-job');
+  bash.runJob('google-manage-keys');
 
   // Try to access data
   const user0AccessQAResExpired = await google.getFileFromBucket(
@@ -304,7 +304,7 @@ Scenario('SA key removal job test: remove expired creds that do not exist in goo
 
   // Run the expired SA key clean up job
   console.log('Clean up expired Service Account keys');
-  bash.runJob('google-manage-keys-job');
+  bash.runJob('google-manage-keys');
 
   // Get list of current creds
   getCredsRes = await fence.do.getUserGoogleCreds(users.user0.accessTokenHeader);

--- a/suites/google/googleServiceAccountKeyTest.js
+++ b/suites/google/googleServiceAccountKeyTest.js
@@ -47,7 +47,7 @@ After(async (google, fence, users) => {
   await fence.complete.suiteCleanup(google, users);
 });
 
-Scenario('Get current SA creds @reqGoogle @disabled', async (fence, users) => {
+Scenario('Get current SA creds @reqGoogle', async (fence, users) => {
   const EXPIRES_IN = 5;
 
   // Make sure there are no creds for this user


### PR DESCRIPTION
Setting correct name to determine the status of the `google-manage-keys` pod.

Currently, it can't find the pod:
```
Running command: gen3 job run google-manage-keys-job -w 
[32mINFO: 22:12:50 -[39m filtering /var/jenkins_home/workspace/GitHub_Org_cdis-manifest_PR-1045/cloud-automation/kube/services/jobs/google-manage-keys-job.yaml with /var/jenkins_home/workspace/GitHub_Org_cdis-manifest_PR-1045/cdis-manifest/jenkins-brain.planx-pla.net/manifest.json
[32mINFO: 22:12:52 -[39m waiting for google-manage-keys to finish
Error from server (NotFound): jobs.batch "google-manage-keys-job" not found
```

Other commits will be added soon.