### PR TITLE
chore(qa): Enable Google tests for new stage preprod .gov url

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -192,7 +192,7 @@ runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these
-envsRequireGoogle="dcp.bionimbus.org internalstaging.datastage.io gen3.datastage.io nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.datastage.io nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
 
 #
 # DataClientCLI tests require a fix to avoid parallel test runs


### PR DESCRIPTION
The pipeline needs to be aware of which environments require google integration tests.
Adding the recently introduced URL for DataSTAGE internal staging:
preprod.gen3.biodatacatalyst.nhlbi.nih.gov