### PR TITLE
chore(qa): Fix logic that compares versions within runTestsIfServiceVersion

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -80,8 +80,7 @@ runTestsIfServiceVersion() {
     versionAsNumber=$currentVersion
   fi
 
-
-  min=$(echo "$3" "$versionAsNumber" | awk '{if ($1 < $2) print $1; else print $2}')
+  min=$(printf "$3\n$versionAsNumber\n" | sort -V | head -n1)
   if [ "$min" = "$3" ]; then
     echo "RUNNING $1 tests b/c $2 version ($currentVersion) is greater than $3"
   else


### PR DESCRIPTION
The version comparison logic from the `runTestsIfServiceVersion` function is not calculating versions properly. This is triggering tests that are not meant to be executed against old Sheepdog versions.
e.g.,
```
RUNNING @indexRecordConsentCodes tests b/c sheepdog version (1.1.6) is greater than 1.1.13
```
From: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS%20GitHub%20Org%2Fcdis-manifest/detail/PR-1173/1/tests/
