### PR TITLE
chore(qa): Improve debugging for intermittent NaN assertion + retries

### DIFF
--- a/suites/google/googleServiceAccountTest.js
+++ b/suites/google/googleServiceAccountTest.js
@@ -2,6 +2,7 @@
 const chai = require('chai');
 
 const { expect } = chai;
+const stringify = require('json-stringify-safe');
 
 const apiUtil = require('../../utils/apiUtil.js');
 const { Bash } = require('../../utils/bash.js');
@@ -149,8 +150,9 @@ Scenario('Register SA from Google Project that doesn’t have fence’s monitori
     googleProject,
     ['test'],
   );
+  console.log(`registerRes: ${stringify(registerRes)}`);
   fence.ask.responsesEqual(registerRes, fence.props.resRegisterServiceAccountFenceNoAccess);
-});
+}).retry(2);
 
 Scenario('Register SA from Google Project with invalid members @reqGoogle', async (fence, users, google) => {
   // Register a google project service account that has a member that's an invalid type


### PR DESCRIPTION
Adding logging line to check the output of the request that attempts to register a google service account from a project that doesn't have the fence monitor account configured.

This scenario is intermittently producing a weird error:
```Error
expected NaN not to be NaN
Stacktrace
expected NaN not to be NaNAssertionError: expected NaN not to be NaN
    at Assertion.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:789:10)```
