### PR TITLE
fix(DRS): Only execute DRS tests if Indexd version is greater than 2.8.0

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -194,6 +194,7 @@ runTestsIfServiceVersion "@centralizedAuth" "fence" "3.0.0"
 runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
+runTestsIfServiceVersion "@drs" "indexd" "2.8.0"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these

--- a/suites/apis/drsEndpointsTest.js
+++ b/suites/apis/drsEndpointsTest.js
@@ -46,17 +46,17 @@ BeforeSuite(async (indexd) => {
   expect(ok).to.be.true;
 });
 
-Scenario('get drs object', async (drs) => {
+Scenario('get drs object @drs', async (drs) => {
   const drsObject = await drs.do.getDrsObject(files.allowed);
   await drs.complete.checkFile(drsObject);
 });
 
-Scenario('get drs no record found', async (drs) => {
+Scenario('get drs no record found @drs', async (drs) => {
   const drsObject = await drs.do.getDrsObject(files.not_allowed);
   await drs.complete.checkRecordExists(drsObject);
 });
 
-Scenario('get drs presigned-url', async (drs, fence) => {
+Scenario('get drs presigned-url @drs', async (drs, fence) => {
   const signedUrlRes = await drs.do.getDrsSignedUrl(files.allowed);
   await fence.complete.checkFileEquals(
     signedUrlRes,
@@ -64,12 +64,12 @@ Scenario('get drs presigned-url', async (drs, fence) => {
   );
 });
 
-Scenario('get drs invalid access id', async (drs, fence) => {
+Scenario('get drs invalid access id @drs', async (drs, fence) => {
   const signedUrlRes = await drs.do.createSignedUrl(files.invalid_protocol);
   await fence.ask.responsesEqual(signedUrlRes, drs.props.resInvalidFileProtocol);
 });
 
-Scenario('get drs presigned-url no auth header', async (drs, fence) => {
+Scenario('get drs presigned-url no auth header @drs', async (drs, fence) => {
   const signedUrlRes = await drs.do.getDrsSignedUrlWithoutHeader(files.allowed);
   fence.ask.responsesEqual(signedUrlRes, drs.props.noAccessToken);
 });


### PR DESCRIPTION
Every PR check will try to run the latest gen3-qa automation which now includes the newly introduced DRS tests, however, the endpoints are only enabled on indexd >= 2.8.0.