### PR TITLE
chore(qa): Skip DRS tests if DRS is not deployed

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -14,7 +14,7 @@ module.exports = function () {
     console.log('********');
     console.log(`SUITE: ${suite.title}`);
     if (suite.title === 'DrsAPI') {
-      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res, body) => {
+      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since endpoint is not enabled on this environment...');

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -1,4 +1,5 @@
 const { event } = require('codeceptjs');
+const request = require('request');
 
 module.exports = function () {
   event.dispatcher.on(event.test.finished, (test) => {
@@ -7,5 +8,22 @@ module.exports = function () {
     console.log(`RESULT: ${test.state}`);
     console.log(`RETRIES: ${test.retryNum}`);
     console.log('********');
+  });
+
+  event.dispatcher.on(event.suite.before, (suite) => {
+    console.log('********');
+    console.log(`SUITE: ${suite.title}`);
+    if (suite.title === 'DrsAPI') {
+      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res, body) => {
+        if (err) { console.log(err); }
+        if (res.statusCode !== 200) {
+          console.log('Skipping DRS tests since endpoint is not enabled on this environment...');
+          suite.tests.map((test) => {
+            test.run = () => console.log(`Ignoring test - ${test.title}`);
+            return test;
+          });
+        }
+      });
+    }
   });
 };

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -17,7 +17,7 @@ module.exports = function () {
       request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
-          console.log('Skipping DRS tests since endpoint is not enabled on this environment...');
+          console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
           suite.tests.map((test) => {
             test.run = () => console.log(`Ignoring test - ${test.title}`);
             return test;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -194,7 +194,6 @@ runTestsIfServiceVersion "@centralizedAuth" "fence" "3.0.0"
 runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
-runTestsIfServiceVersion "@drs" "indexd" "2.8.0"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these


### PR DESCRIPTION
Leverage CodeceptJS hooks to check if DRS endpoints are enabled in the environment and SKIP the tests if the feature is not in place.