### PR TITLE
Chore/smarter drs test

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -19,9 +19,9 @@ module.exports = function () {
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
           suite.tests.forEach((test) => {
-            test.run = function skip() {
+            test.run = function skip() { // eslint-disable-line func-names
               console.log(`Ignoring test - ${test.title}`);
-              this.skip()
+              this.skip();
             };
           });
         }

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -16,7 +16,7 @@ module.exports = function () {
     if (suite.title === 'DrsAPI') {
       request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
-        if (res.statusCode === 200) {
+        if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
           suite.tests.forEach((test) => {
             test.run = function skip() { // eslint-disable-line func-names

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -16,7 +16,7 @@ module.exports = function () {
     if (suite.title === 'DrsAPI') {
       request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
-        if (res.statusCode !== 200) {
+        if (res.statusCode === 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
           suite.tests.forEach((test) => {
             test.run = function skip() { // eslint-disable-line func-names

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -14,7 +14,7 @@ module.exports = function () {
     console.log('********');
     console.log(`SUITE: ${suite.title}`);
     if (suite.title === 'DrsAPI') {
-      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res, body) => {
+      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since endpoint is not enabled on this environment...');

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -1,4 +1,5 @@
 const { event } = require('codeceptjs');
+const request = require('request');
 
 module.exports = function () {
   event.dispatcher.on(event.test.finished, (test) => {
@@ -7,5 +8,22 @@ module.exports = function () {
     console.log(`RESULT: ${test.state}`);
     console.log(`RETRIES: ${test.retryNum}`);
     console.log('********');
+  });
+
+  event.dispatcher.on(event.suite.before, (suite) => {
+    console.log('********');
+    console.log(`SUITE: ${suite.title}`);
+    if (suite.title === 'DrsAPI') {
+      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res, body) => {
+        if (err) { console.log(err); }
+        if (res.statusCode !== 200) {
+          console.log('Skipping DRS tests since endpoint is not enabled on this environment...');
+          suite.tests.map((test) => {
+            test.run = () => console.log(`Ignoring test - ${test.title}`);
+            return test;
+          });
+        }
+      });
+    }
   });
 };

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -18,9 +18,11 @@ module.exports = function () {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
-          suite.tests.map((test) => {
-            test.run = () => console.log(`Ignoring test - ${test.title}`);
-            return test;
+          suite.tests.forEach((test) => {
+            test.run = function skip() {
+              console.log(`Ignoring test - ${test.title}`);
+              this.skip()
+            };
           });
         }
       });

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -17,7 +17,7 @@ module.exports = function () {
       request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
-          console.log('Skipping DRS tests since endpoint is not enabled on this environment...');
+          console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');
           suite.tests.map((test) => {
             test.run = () => console.log(`Ignoring test - ${test.title}`);
             return test;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -194,7 +194,6 @@ runTestsIfServiceVersion "@centralizedAuth" "fence" "3.0.0"
 runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
-runTestsIfServiceVersion "@drs" "indexd" "2.8.0"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -266,19 +266,6 @@ portalApp="$(g3kubectl get configmaps manifest-global -o json | jq -r '.data.por
 portalConfigURL="https://${hostname}/data/config/${portalApp}.json"
 portalVersion="$(g3kubectl get configmaps manifest-all -o json | jq -r '.data.json | fromjson.versions.portal')"
 
-check_restful_endpoint() {
-  the_url=$1
-  result=$(curl -L -s -o /dev/null -w "%{http_code}" "$the_url")
-  if [ $result != 200 ]; then
-    echo "Skip tests for $2"
-    donot "$2"
-  else
-    echo "Run $2 tests"
-  fi
-}
-
-check_restful_endpoint "https://${hostname}/index/ga4gh/drs/v1/objects" "@drs"
-
 # do not run portal related tests for NDE portal
 if [[ "$portalVersion" == *"data-ecosystem-portal"* ]]; then
   donot '@portal'


### PR DESCRIPTION
Leverage CodeceptJS hooks to check if DRS endpoints are enabled in the environment and SKIP the tests if the feature is not in place.

Trying again by invoking the `skip()` function.