### PR TITLE
chore(qa): Enable Google tests for BDCat PROD

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -197,7 +197,7 @@ runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these
-envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
 
 #
 # DataClientCLI tests require a fix to avoid parallel test runs

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -197,7 +197,7 @@ runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these
-envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.datastage.io nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
 
 #
 # DataClientCLI tests require a fix to avoid parallel test runs


### PR DESCRIPTION
Enable google tests for cdis-manifests PRs that target the BDCat prod environment:
`gen3.biodatacatalyst.nhlbi.nih.gov/manifest.json`