### PR TITLE
fix(qa): data-simulator should use /usr/bin/pip3

### DIFF
--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -63,7 +63,8 @@ echo "Leaf node set to: $leafNode"
 # try to trick pip into working in the WORKSPACE
 #
 export HOME="${WORKSPACE:-$HOME}"
-pip3 install --user -r requirements.txt
+/usr/bin/pip3 install cdislogging
+/usr/bin/pip3 install --user -r requirements.txt
 #python setup.py develop --user
 
 # Fail script if any of following commands fail


### PR DESCRIPTION
legacy pip3:
```root@4fcf820f9c68:/# which pip3
/usr/bin/pip3
```
New pip3:
```
jenkins@jenkins-deployment-997f489d6-rkk77:~/workspace/CDIS_GitHub_Org_gen3-qa_PR-279/gen3-qa$ which pip3
/var/jenkins_home/.local/bin/pip3
```

Tested here:
```
jenkins@jenkins-deployment-997f489d6-rkk77:~/workspace/CDIS_GitHub_Org_gen3-qa_PR-279/gen3-qa$ /usr/bin/pip3 install cdislogging
...Successfully built cdislogging
Installing collected packages: cdislogging
Successfully installed cdislogging-1.0.0
```