### PR TITLE
chore(qa): Enable Google tests for TheAnvil environments

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -197,7 +197,7 @@ runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these
-envsRequireGoogle="dcp.bionimbus.org preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+envsRequireGoogle="dcp.bionimbus.org internalstaging.theanvil.io gen3.theanvil.io preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
 
 #
 # DataClientCLI tests require a fix to avoid parallel test runs

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -197,7 +197,7 @@ runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these
-envsRequireGoogle="dcp.bionimbus.org internalstaging.theanvil.io gen3.theanvil.io preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
+envsRequireGoogle="dcp.bionimbus.org internalstaging.theanvil.io staging.theanvil.io gen3.theanvil.io preprod.gen3.biodatacatalyst.nhlbi.nih.gov internalstaging.datastage.io gen3.biodatacatalyst.nhlbi.nih.gov nci-crdc-staging.datacommons.io nci-crdc.datacommons.io"
 
 #
 # DataClientCLI tests require a fix to avoid parallel test runs


### PR DESCRIPTION
We must run Google integration tests against TheAnvil `cdis-manifest` PRs.