### PR TITLE
chore(qa): Add timestamp to test.finished hook to assist with debugging

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -7,6 +7,7 @@ module.exports = function () {
     console.log(`TEST: ${test.title}`);
     console.log(`RESULT: ${test.state}`);
     console.log(`RETRIES: ${test.retryNum}`);
+    console.log(`TIMESTAMP: ${new Date()}`);
     console.log('********');
   });
 


### PR DESCRIPTION
We are facing several issues due to long-running tests and expired access tokens.
This change will help us benchmark and investigate the root cause.