### PR TITLE
fix(qa): Set default value for selectedTest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@chore/set_default_empty_string_for_selectedtest_arg') _
+@Library('cdis-jenkins-lib@master') _
 
 testPipeline {
   // tell the pipeline to not checkout `gen3-qa:master`

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@chore/set_default_empty_string_for_selectedtest_arg') _
 
 testPipeline {
   // tell the pipeline to not checkout `gen3-qa:master`

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -121,7 +121,7 @@ namespaceName="${KUBECTL_NAMESPACE}"
 service="${service:-""}"
 testedEnv="${testedEnv:-""}"
 isGen3Release="${isGen3Release:false}"
-selectedTest="${selectedTest:-""}"
+selectedTest="${selectedTest:-"all"}"
 
 while [[ $# -gt 0 ]]; do
   key="$(echo "$1" | sed -e 's/^-*//' | sed -e 's/=.*$//')"
@@ -312,7 +312,7 @@ fi
 
 exitCode=0
 
-if [ "$selectedTest" == "" ]; then
+if [ "$selectedTest" == "all" ]; then
   (
     export NAMESPACE="$namespaceName"
     export testedEnv="$testedEnv"


### PR DESCRIPTION
Looks like Jenkins doesn't like empty strings as default values.

Causing failures:
```
StackTrace:
hudson.AbortException: aborting build - testsuite failed
	at org.jenkinsci.plugins.workflow.steps.ErrorStep$Execution.run(ErrorStep.java:63)
	at org.jenkinsci.plugins.workflow.steps.ErrorStep$Execution.run(ErrorStep.java:50)
	at org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution.start(SynchronousStepExecution.java:38)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:286)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:179)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
	at groovy.lang.MetaClassImpl.invokeMethodOnGroovyObject(MetaClassImpl.java:1278)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1172)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:810)
	at groovy.lang.GroovyObjectSupport.invokeMethod(GroovyObjectSupport.java:46)
	at groovy.lang.MetaClassImpl.invokeMethodOnGroovyObject(MetaClassImpl.java:1278)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1172)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
	at testHelper.runIntegrationTests(testHelper.groovy:50)
	at testHelper.gen3Qa(testHelper.groovy:21)
	at ___cps.transform___(Native Method)
```