### PR TITLE
fix(qa): Apply @reqGoogle only if the tag is found

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -333,7 +333,7 @@ else
   additionalArgs=""
   foundReqGoogle=$(grep "@reqGoogle" ${selectedTest})
   if [ -n "$foundReqGoogle" ]; then
-    additionalArgs="--grep '@reqGoogle'"
+    additionalArgs="--grep @reqGoogle"
   fi
   npm 'test' -- --reporter mocha-multi --verbose ${additionalArgs} ${selectedTest}
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -330,7 +330,12 @@ EOM
     #    dryrun npm 'test' -- --reporter mocha-multi --verbose --grep '@FRICKJACK'
   ) || exitCode=1
 else
-  npm 'test' -- --reporter mocha-multi --verbose --grep '@reqGoogle' ${selectedTest}
+  additionalArgs=""
+  foundReqGoogle=$(grep "@reqGoogle" ${selectedTest})
+  if [ -n "$foundReqGoogle" ]; then
+    additionalArgs="--grep '@reqGoogle'"
+  fi
+  npm 'test' -- --reporter mocha-multi --verbose ${additionalArgs} ${selectedTest}
 fi
 
 exit $exitCode


### PR DESCRIPTION
Cannot add `--grep @reqGoogle` for all tests because that is suppressing some of the test runs.