### PR TITLE
chore(qa): Custom health check for dataguids.org

### DIFF
--- a/check-pod-health.sh
+++ b/check-pod-health.sh
@@ -8,12 +8,17 @@ if [[ "$KUBECTL_NAMESPACE" == "default" ]]; then
   commons_name="qa"
 fi
 commons_url="https://${commons_name}.planx-pla.net"
+indexd="${commons_url}/index/_status"
 sheepdog="${commons_url}/api/_status"
 peregrine="${commons_url}/peregrine/_status"
 portal="${commons_url}/"
 fence="${commons_url}/user/jwt/keys"
 selenium="localhost:4444/wd/hub/sessions"
-health_endpoints=( $sheepdog $peregrine $portal $fence $selenium )
+if [ "$testedEnv" == "dataguids.org" ]; then
+  health_endpoints=( $indexd $portal $selenium )
+else
+  health_endpoints=( $sheepdog $peregrine $portal $fence $selenium )
+fi
 
 exit_code=0
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -312,10 +312,12 @@ fi
 
 exitCode=0
 
+# set required vars
+export NAMESPACE="$namespaceName"
+export testedEnv="$testedEnv"
+
 if [ "$selectedTest" == "all" ]; then
   (
-    export NAMESPACE="$namespaceName"
-    export testedEnv="$testedEnv"
     # no interactive tests
     export GEN3_INTERACTIVE=false
     cat - <<EOM


### PR DESCRIPTION
Currently dataguids.org PRs fail on:
```
+ bash ./check-pod-health.sh
Health https://jenkins-niaid.planx-pla.net/api/_status             : 000
Health https://jenkins-niaid.planx-pla.net/peregrine/_status       : 000
Health https://jenkins-niaid.planx-pla.net/                        : 200
Health https://jenkins-niaid.planx-pla.net/user/jwt/keys           : 000
Health localhost:4444/wd/hub/sessions                              : 200
script returned exit code 1
```
This PR introduces a custom health check logic that verifies only indexd, portal and selenium.