### PR TITLE
chore(token timeout): to 7200 secs

### DIFF
--- a/utils/user.js
+++ b/utils/user.js
@@ -8,7 +8,7 @@ const { Bash } = require('./bash');
 
 const bash = new Bash();
 
-const DEFAULT_TOKEN_EXP = 3600;
+const DEFAULT_TOKEN_EXP = 7200;
 let indexdCache = null;
 
 


### PR DESCRIPTION
increase token timeout to accommodate long running jobs

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

