### PR TITLE
fix(qa): Skip @dataClientCLI for dataUpload labeled tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -339,7 +339,7 @@ else
   if [ -n "$foundReqGoogle" ]; then
     additionalArgs="--grep @reqGoogle"
   elif [ -n "$foundDataClientCLI" ]; then
-    additionalArgs="--grep @dataClientCLI --invert"
+    additionalArgs="--grep '@indexRecordConsentCodes|@dataClientCLI' --invert"
   fi
   npm 'test' -- --reporter mocha-multi --verbose ${additionalArgs} ${selectedTest}
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -339,7 +339,7 @@ else
   if [ -n "$foundReqGoogle" ]; then
     additionalArgs="--grep @reqGoogle"
   elif [ -n "$foundDataClientCLI" ]; then
-    additionalArgs="--grep '@indexRecordConsentCodes|@dataClientCLI' --invert"
+    additionalArgs="--grep @indexRecordConsentCodes|@dataClientCLI --invert"
   fi
   npm 'test' -- --reporter mocha-multi --verbose ${additionalArgs} ${selectedTest}
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -335,8 +335,11 @@ EOM
 else
   additionalArgs=""
   foundReqGoogle=$(grep "@reqGoogle" ${selectedTest})
+  foundDataClientCLI=$(grep "@dataClientCLI" ${selectedTest})
   if [ -n "$foundReqGoogle" ]; then
     additionalArgs="--grep @reqGoogle"
+  elif [ -n "$foundDataClientCLI" ]; then
+    additionalArgs="--grep @dataClientCLI --invert"
   fi
   npm 'test' -- --reporter mocha-multi --verbose ${additionalArgs} ${selectedTest}
 fi


### PR DESCRIPTION
Two tests that are not meant to be executed are failing consistently:

1. Data file upload flow: File upload and download via client @dataClientCLI @dataUpload – File upload and download via client @dataClientCLI @dataUpload
2. Data file upload flow File upload with consent codes @dataUpload @indexRecordConsentCodes – File upload with consent codes @dataUpload @indexRecordConsentCodes

As per:
```
#
# DataClientCLI tests require a fix to avoid parallel test runs
# contending over config files in the home directory
#
donot '@dataClientCLI'
```
https://github.com/uc-cdis/gen3-qa/blob/master/run-tests.sh#L212