### PR TITLE
Task/tests for indexing gui and sower jobs

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -1,4 +1,3 @@
-const request = require('request');
 const { Env } = require('./utils/env');
 
 Env.setupEnvVariables();
@@ -69,6 +68,7 @@ exports.config = {
 
     // Pages
     home: './services/portal/home/homeService.js',
+    indexing: './services/portal/indexing/indexingService.js',
     login: './services/portal/login/loginService.js',
     explorer: './services/portal/explorer/explorerService.js',
     portalDataUpload: './services/portal/dataUpload/dataUploadService.js',

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -287,6 +287,14 @@ if ! [[ "$portalVersion" == *"master" ]]; then
   donot '@loginRedirect'
 fi
 
+# check if manifest indexing jobs are set in sower block
+# this is a temporary measure while PXP-4796 is not implemented
+checkForPresenceOfManifestIndexingSowerJob=$(kc get cm manifest-sower -o yaml | grep manifest-indexing)
+if [ -z "$checkForPresenceOfManifestIndexingSowerJob" ]; then
+  echo "the manifest-indexing sower job was not found, skip @indexing tests"; 
+  donot '@indexing'
+fi
+
 if ! (g3kubectl get pods --no-headers -l app=manifestservice | grep manifestservice) > /dev/null 2>&1 ||
 ! (g3kubectl get pods --no-headers -l app=wts | grep wts) > /dev/null 2>&1; then
   donot '@exportToWorkspaceAPI'

--- a/services/portal/home/homeProps.js
+++ b/services/portal/home/homeProps.js
@@ -24,7 +24,7 @@ module.exports = {
 
   googleLoginButton: {
     locator: {
-      xpath: '//button[contains(text(), \'Google\')]',
+      xpath: 'xpath: //button[contains(text(), \'Google\') or contains(text(), \'BioData Catalyst Developer Login\')]',
     },
   },
 

--- a/services/portal/indexing/indexingProps.js
+++ b/services/portal/indexing/indexingProps.js
@@ -1,0 +1,6 @@
+/**
+ * Explorer Page Properties
+ */
+module.exports = {
+  path: '/indexing',
+};

--- a/services/portal/indexing/indexingService.js
+++ b/services/portal/indexing/indexingService.js
@@ -1,0 +1,10 @@
+const indexingProps = require('./indexingProps.js');
+const indexingTasks = require('./indexingTasks.js');
+
+/**
+ * indexing service
+ */
+module.exports = {
+  props: indexingProps,
+  do: indexingTasks,
+};

--- a/services/portal/indexing/indexingService.js~
+++ b/services/portal/indexing/indexingService.js~
@@ -1,0 +1,8 @@
+const explorerProps = require('./explorerProps.js');
+
+/**
+ * indexing service
+ */
+module.exports = {
+  props: indexingProps,
+};

--- a/services/portal/indexing/indexingTasks.js
+++ b/services/portal/indexing/indexingTasks.js
@@ -1,0 +1,12 @@
+const indexingProps = require('./indexingProps.js');
+
+const I = actor();
+
+/**
+ * indexing Tasks
+ */
+module.exports = {
+  goToIndexingPage() {
+    I.amOnPage(indexingProps.path);
+  },
+};

--- a/services/portal/indexing/indexingTasks.js~
+++ b/services/portal/indexing/indexingTasks.js~
@@ -1,0 +1,14 @@
+const indexingProps = require('./indexingProps.js');
+
+const I = actor();
+
+/**
+ * indexing Tasks
+ */
+module.exports = {
+  goToIndexingPage() {
+    I.amOnPage(indexingProps.path);
+      indexing-page
+    portal.seeProp(homeProps.ready_cue, 60);
+  },
+}

--- a/suites/portal/indexingPageTest.js
+++ b/suites/portal/indexingPageTest.js
@@ -1,11 +1,12 @@
 /*
+ Indexing GUI & Indexing/Manifest Sower Jobs (PXP-5786)
  This test plan has a few pre-requisites:
  1. Sower must be deployed and
  2. The environment's manifest must have the indexing jobs declared
     within the sower config block (manifest-indexing & indexd-manifest)
  3. The Indexing GUI is only available in data-portal >= 2.24.9
 */
-Feature('Indexing page - PXP-5786');
+Feature('Indexing GUI');
 
 const { expect } = require('chai');
 const { sleepMS, Gen3Response } = require('../../utils/apiUtil.js');

--- a/suites/portal/indexingPageTest.js
+++ b/suites/portal/indexingPageTest.js
@@ -1,0 +1,126 @@
+/*
+ This test plan has a few pre-requisites:
+ 1. Sower must be deployed and
+ 2. The environment's manifest must have the indexing jobs declared
+    within the sower config block (manifest-indexing & indexd-manifest)
+ 3. The Indexing GUI is only available in data-portal >= 2.24.9
+*/
+Feature('Indexing page - PXP-5786');
+
+// const stringify = require('json-stringify-safe');
+const { expect } = require('chai');
+const { sleepMS, Gen3Response } = require('../../utils/apiUtil.js');
+const { Bash } = require('../../utils/bash.js');
+
+const bash = new Bash();
+
+const testGUID = 'dg123/c2da639f-aa25-4c4d-8e89-02a143788268';
+const testHash = '73d643ec3f4beb9020eef0beed440ad4';
+
+/* eslint-disable no-tabs */
+const contentsOfTestManifest = `GUID	md5	size	acl	url
+${testGUID}	${testHash}	13	[jenkins2]	s3://cdis-presigned-url-test/testdata`;
+
+BeforeSuite(async (I, files, indexd) => {
+  console.log('Setting up dependencies...');
+  I.cache = {};
+
+  I.cache.UNIQUE_NUM = Date.now();
+
+  // create a local small file to upload. store its size and hash
+  await files.createTmpFile(`./manifest_${I.cache.UNIQUE_NUM}.tsv`, contentsOfTestManifest);
+
+  console.log('deleting existing test records...');
+  const listOfIndexdRecords = await I.sendGetRequest(
+    `${indexd.props.endpoints.get}`,
+  ).then((res) => new Gen3Response(res));
+
+  listOfIndexdRecords.data.records.forEach(async (record) => {
+    console.log(record.did);
+    await indexd.do.deleteFile({ did: record.did });
+  });
+});
+
+AfterSuite(async (I, files) => {
+  // clean up test files
+  files.deleteFile(`manifest_${I.cache.UNIQUE_NUM}.tsv`);
+});
+
+async function checkPod(podName, nAttempts = 3) {
+  for (let i = 0; i < nAttempts; i += 1) {
+    try {
+      console.log(`waiting for the ${podName} sower job/pod to show up... - attempt ${i}`);
+      await sleepMS(10000);
+      const greppingPod = bash.runCommand(`g3kubectl get pods | grep ${podName}`);
+      console.log(`grep result: ${greppingPod}`);
+      if (greppingPod.includes(podName)) {
+        console.log('the pod was found! Proceed with the assertion checks..');
+        await sleepMS(10000);
+        break;
+      }
+    } catch (e) {
+      console.log(`Failed to find the ${podName} pod on attempt ${i}:`);
+      console.log(e);
+      if (i === nAttempts - 1) {
+        throw e;
+      }
+    }
+  }
+}
+
+// Scenario #1 - Login and navigate to the indexing page and upload dummy manifest
+Scenario('Navigate to the indexing page and upload a test manifest @indexing', async (I, indexing, home) => {
+  home.do.goToHomepage();
+  home.complete.login();
+  indexing.do.goToIndexingPage();
+  I.waitForElement({ css: '.indexing-page' }, 10);
+  I.click('.index-flow-form'); // after clicking open window file upload dialog
+  await I.attachFile('input[type=\'file\']', `manifest_${I.cache.UNIQUE_NUM}.tsv`);
+  I.click({ xpath: 'xpath: //button[contains(text(), \'Index Files\')]' });
+
+  await checkPod('manifest-indexing');
+
+  const nAttempts = 5;
+  for (let i = 0; i < nAttempts; i += 1) {
+    console.log(`Looking up the indexd record... - attempt ${i}`);
+    const indexdRecordRes = await I.sendGetRequest(
+      `/index/${testGUID}`,
+    ).then((res) => new Gen3Response(res));
+
+    if (indexdRecordRes.data.hashes) {
+      expect(indexdRecordRes.data.hashes.md5).to.equal(testHash);
+    } else {
+      console.log(`WARN: The indexd record has not been created yet... - attempt ${i}`);
+      await sleepMS(5000);
+      if (i === nAttempts - 1) {
+        const manifestIndexingLogs = bash.runCommand('gen3 job logs manifest-indexing');
+        console.log(`manifest-indexing logs: ${manifestIndexingLogs}`);
+        throw new Error(`ERROR: The manifest indexing operation failed. Response: ${indexdRecordRes.data}`);
+      }
+    }
+  }
+});
+
+// Scenario #2 - Login and navigate to the indexing page and download a full indexd manifest
+Scenario('Navigate to the indexing page and download a full indexd manifest @indexing', async (I, indexing, home) => {
+  home.do.goToHomepage();
+  home.complete.login();
+  indexing.do.goToIndexingPage();
+  I.waitForElement({ css: '.indexing-page' }, 10);
+  I.click({ xpath: 'xpath: //button[contains(text(), \'Download\')]' });
+
+  await checkPod('indexd-manifest');
+
+  const waitingThreshold = 30;
+  console.log('Waiting for Green status DONE to show up on the page...');
+  I.waitForElement({ css: '.index-files-green-label' }, waitingThreshold);
+
+  I.handleDownloads();
+  I.click({ xpath: 'xpath: //button[contains(text(), \'Download Manifest\')]' });
+  I.amInPath('output/downloads');
+  const downloadedFileNames = I.grabFileNames();
+
+  console(`downloaded file: ${downloadedFileNames[0]}`);
+
+  expect(testHash).to.equal('73d643ec3f4beb9020eef0beed440ad4');
+});

--- a/test_setup.js
+++ b/test_setup.js
@@ -250,6 +250,12 @@ module.exports = async function (done) {
     assertEnvVars(basicVars.concat(googleVars, submitDataVars));
     console.log('TEST_DATA_PATH: ', process.env.TEST_DATA_PATH);
 
+    // If testedEnv is not defined, infer FQDN based on the NAMESPACE
+    if (process.env['testedEnv'] === '' || process.env['testedEnv'] === undefined) {
+      process.env.testedEnv = `${process.env.NAMESPACE}.planx-pla.net`;
+      console.log(`INFO: Setting testedEnv var to ${process.env.testedEnv}`);
+    }
+
     if (isIncluded('@reqGoogle')) {
       createGoogleTestBuckets();
       await setupGoogleProjectDynamic();


### PR DESCRIPTION
Jira Ticket: [PXP-5786](https://ctds-planx.atlassian.net/browse/PXP-5786)

This PR comprises 2 new automated test scenarios for the Indexing GUI `/indexing` & the recently-added sower jobs that allow the users to:
1. Upload and register a set of indexd records through a manifest and 
2. Generate and download a manifest containing a full list of indexd records from the Gen3 Commons environment.

This was tested against qa-dcp and all the required changes have also been applied to Jenkins CI environments. It has also been executed manually against `jenkins-genomel`, which presented positive results.

### New Features
New automated test with the tag @indexing.

### Improvements
Adding condition to `run-tests.sh` to only execute the tests if the `sower-manifest` configmap contains the relevant sower jobs declared in there. This is a temporary measure until the invalid URLs can redirect  the user to a proper 404 Not Found page.

### tests

********
TEST: Navigate to the indexing page and upload a test manifest @indexing
RESULT: passed
RETRIES: 0
TIMESTAMP: Wed Apr 29 2020 16:25:55 GMT-0500 (Central Daylight Time)
********
  ✔ OK in 86868ms

********
TEST: Navigate to the indexing page and download a full indexd manifest @indexing
RESULT: passed
RETRIES: 0
TIMESTAMP: Wed Apr 29 2020 16:26:45 GMT-0500 (Central Daylight Time)
********
  ✔ OK in 49398ms