### PR TITLE
chore(qa): Introduce Selenium hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfil
 docker run -d -p 4444:4444 --name=selenium --rm -v /dev/shm:/dev/shm selenium/standalone-chrome
 ```
 
+Edit your `/etc/hosts` file to point the `selenium-hub` host to your Docker container running on `localhost`.
+_/etc/hosts_
+```
+127.0.0.1 selenium-hub
+```
+
+More information about Selenium Hub in [`cloud-automation's documentation`](https://github.com/uc-cdis/cloud-automation/blob/master/kube/selenium/jenkins/README.md)
+
 ### Test with dev environment (ssh backend access)
 
 Run a test locally against a dev environment that you can ssh to and run gen3 commands like this:

--- a/check-pod-health.sh
+++ b/check-pod-health.sh
@@ -13,7 +13,7 @@ sheepdog="${commons_url}/api/_status"
 peregrine="${commons_url}/peregrine/_status"
 portal="${commons_url}/"
 fence="${commons_url}/user/jwt/keys"
-selenium="selenium-hub:4444/wd/hub/sessions"
+selenium="selenium-hub:4444/wd/hub/status"
 if [ -n $1 ] && [ "$1" == "dataguids.org" ]; then
   health_endpoints=( $indexd $portal $selenium )
 else

--- a/check-pod-health.sh
+++ b/check-pod-health.sh
@@ -13,7 +13,7 @@ sheepdog="${commons_url}/api/_status"
 peregrine="${commons_url}/peregrine/_status"
 portal="${commons_url}/"
 fence="${commons_url}/user/jwt/keys"
-selenium="localhost:4444/wd/hub/sessions"
+selenium="selenium-hub:4444/wd/hub/sessions"
 if [ -n $1 ] && [ "$1" == "dataguids.org" ]; then
   health_endpoints=( $indexd $portal $selenium )
 else

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -20,6 +20,7 @@ exports.config = {
             '--disable-gpu',
             '--window-size=1920,1080',
             '--whitelisted-ips=*',
+            '--disable-features=VizDisplayCompositor',
           ],
         },
       },

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -8,6 +8,7 @@ exports.config = {
   output: './output',
   helpers: {
     WebDriver: {
+      host: 'selenium-hub',
       url: `https://${process.env.HOSTNAME}`,
       smartWait: 5000,
       browser: 'chrome',
@@ -18,6 +19,7 @@ exports.config = {
             '--headless', // for dev, you can comment this line to open actual chrome for easier test
             '--disable-gpu',
             '--window-size=1920,1080',
+            '--whitelisted-ips=*',
           ],
         },
       },


### PR DESCRIPTION
Innovation day project.

This PR contains changes to adjust documentation and to set all `gen3-qa` tests to run against Selenium Hub.

### New Features
Tests running on Selenium Hub

### Breaking Changes
The `codecept.conf.js` script is now pointing to the k8s service `selenium-hub`

### Improvements
This should address the flakyness around Selenium/Webdriver operations:
To get rid of errors such as
> chrome not reachable (Session info: headless chrome=70.0.3538.77) (Driver info: chromedriver=2.43.600233

### Deployment changes
The selenium side car defined in the jenkins deployment YAMl should, eventually, be decommissioned. 
You will only be able to run tests locally if you edit your `/etc/hosts` file to point `selenium-hub` to `127.0.0.1`.