### PR TITLE
fix(qa): Only run indexing tests if data-portal >= 2.26.0

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -200,6 +200,7 @@ runTestsIfServiceVersion "@centralizedAuth" "fence" "3.0.0"
 runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
+runTestsIfServiceVersion "@indexing" "portal" "2.26.0"
 
 # environments that use DCF features
 # we only run Google Data Access tests for cdis-manifest PRs to these


### PR DESCRIPTION
The test is being executed for `cdis-manifest` PRs whose environments do not have a valid `data-portal` version.