### PR TITLE
removing hard coded --public False

### DIFF
--- a/test_setup.js
+++ b/test_setup.js
@@ -118,14 +118,14 @@ function createGoogleTestBuckets() {
       let { bucketId } = fenceProps.googleBucketInfo.QA;
       let { googleProjectId } = fenceProps.googleBucketInfo.QA;
       let projectAuthId = 'QA';
-      let fenceCmd = `fence-create google-bucket-create --unique-name ${bucketId} --google-project-id ${googleProjectId} --project-auth-id ${projectAuthId} --public False`;
+      let fenceCmd = `fence-create google-bucket-create --unique-name ${bucketId} --google-project-id ${googleProjectId} --project-auth-id ${projectAuthId}`;
       console.log(`Running: ${fenceCmd}`);
       const responseQABucket = bash.runCommand(fenceCmd, 'fence');
 
       bucketId = fenceProps.googleBucketInfo.test.bucketId;
       googleProjectId = fenceProps.googleBucketInfo.test.googleProjectId;
       projectAuthId = 'test';
-      fenceCmd = `fence-create google-bucket-create --unique-name ${bucketId} --google-project-id ${googleProjectId} --project-auth-id ${projectAuthId} --public False`;
+      fenceCmd = `fence-create google-bucket-create --unique-name ${bucketId} --google-project-id ${googleProjectId} --project-auth-id ${projectAuthId}`;
       console.log(`Running: ${fenceCmd}`);
       const responseTestBucket = bash.runCommand(fenceCmd, 'fence');
 


### PR DESCRIPTION
Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
- Remove hard coded instances of google-bucket-create with both --public and --project-auth-id. This is because public and project-auth-id are mutually exclusive. 

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
