### PR TITLE
fix(qa): Suppress bash failures to grep the manifest-indexing configmap

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -311,7 +311,9 @@ fi
 
 # check if manifest indexing jobs are set in sower block
 # this is a temporary measure while PXP-4796 is not implemented
+set +e
 checkForPresenceOfManifestIndexingSowerJob=$(g3kubectl get cm manifest-sower -o yaml | grep manifest-indexing)
+set -e
 if [ -z "$checkForPresenceOfManifestIndexingSowerJob" ]; then
   echo "the manifest-indexing sower job was not found, skip @indexing tests"; 
   donot '@indexing'


### PR DESCRIPTION
PRs that do not declare the manifest indexing sower jobs are failing:
```
++ /usr/bin/kubectl --namespace=jenkins-brain get cm manifest-sower -o yaml
Error from server (NotFound): configmaps "manifest-sower" not found
+ checkForPresenceOfManifestIndexingSowerJob=
```
This change should suppress the immediate failure caused by the non-zero return code produced by the `grep` command.