### PR TITLE
fix(qa): Quick fix to unblock indexing GUI tests

### DIFF
--- a/suites/portal/indexingPageTest.js
+++ b/suites/portal/indexingPageTest.js
@@ -18,7 +18,7 @@ const testGUID = 'dg123/c2da639f-aa25-4c4d-8e89-02a143788268';
 const testHash = '73d643ec3f4beb9020eef0beed440ad4';
 
 /* eslint-disable no-tabs */
-const contentsOfTestManifest = `GUID	md5	file_size	acl	authz	urls
+const contentsOfTestManifest = `GUID	md5	size	acl	authz	urls
 ${testGUID}	${testHash}	13	jenkins2		s3://cdis-presigned-url-test/testdata`;
 
 const expectedResult = `${testGUID},s3://cdis-presigned-url-test/testdata,,jenkins2,${testHash},13,`;


### PR DESCRIPTION
Renaming tsv header to avoid this error:
```
qa-dcp@cdistest_dev_admin:~$ kc logs manifest-indexing-jdlch-s7x68
Start to index the manifest ...
Start the process ...
Progress: 100.0%
Traceback (most recent call last):
  File "manifest_indexing_job.py", line 76, in <module>
    write_csv(output_manifest, files, headers)
  File "/gen3/utils.py", line 57, in write_csv
    writer.writerow(f)
  File "/usr/local/lib/python3.6/csv.py", line 155, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
  File "/usr/local/lib/python3.6/csv.py", line 151, in _dict_to_list
    + ", ".join([repr(x) for x in wrong_fields]))
ValueError: dict contains fields not in fieldnames: 'size'
```