### PR TITLE
fix(qa): Fixing Gen3 CLI/PATH after Ubuntu 18 upgrade

### DIFF
--- a/utils/commanders/sshk8s.js
+++ b/utils/commanders/sshk8s.js
@@ -24,11 +24,11 @@ class SshK8s extends Base {
     const namespace = process.env.NAMESPACE;
     const commonsUser = userFromNamespace(namespace);
     if (service === undefined) {
-      return cleanResult(execSync(`ssh ${commonsUser}@cdistest_dev.csoc 'source ~/.bashrc; ${cmd}'`,
+      return cleanResult(execSync(`ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; source ~/.bashrc; ${cmd}'`,
         { shell: '/bin/bash' }).toString('utf8'));
     }
     return cleanResult(execSync(
-      `ssh ${commonsUser}@cdistest_dev.csoc 'source ~/.bashrc; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
+      `ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
       { shell: '/bin/sh' },
     ).toString('utf8'));
   }


### PR DESCRIPTION
fix for:
```
bash: gen3: command not found
bash: g3kubectl: command not found
```