### PR TITLE
chore(qa): Improve productivity with Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,15 @@ task :default => :selenium
 desc "start selenium"
 task :selenium do
   sh('docker stop selenium-hub || true')
-  sh('set +e && docker stop selenium-node || true')
+  sh('docker stop selenium-node || true')
   sh('docker run --rm -d -p 4444:4444 --name=selenium-hub --rm -v /dev/shm:/dev/shm selenium/hub:3.141.59')
   sh('docker run --rm -d --link selenium-hub --name=selenium-node selenium/node-chrome:3.141.59')
+end
+
+desc "stop selenium containers"
+task :stop-selenium do
+  sh('docker stop selenium-hub || true')
+  sh('docker stop selenium-node || true')
 end
 
 desc "start grafana and influxdb"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,17 @@
+require 'rake'
+
+task :default => :selenium
+
+desc "start selenium"
+task :selenium do
+  sh('docker stop selenium-hub || true')
+  sh('set +e && docker stop selenium-node || true')
+  sh('docker run --rm -d -p 4444:4444 --name=selenium-hub --rm -v /dev/shm:/dev/shm selenium/hub:3.141.59')
+  sh('docker run --rm -d --link selenium-hub --name=selenium-node selenium/node-chrome:3.141.59')
+end
+
+desc "start grafana and influxdb"
+task :monitoring do
+  sh('docker-compose -f load-testing/grafana/docker-compose.yaml stop')
+  sh('docker-compose -f load-testing/grafana/docker-compose.yaml up -d')
+end


### PR DESCRIPTION
How it works:

# Just install it:
`gem install rake`

# And then use it:
```
% rake
docker stop selenium-hub || true
selenium-hub
set +e && docker stop selenium-node || true
selenium-node
docker run --rm -d -p 4444:4444 --name=selenium-hub --rm -v /dev/shm:/dev/shm selenium/hub:3.141.59
6fd2f721c244077db505f7cbb15b64cf1857d494337f22b825ee8ba264f1ae07
docker run --rm -d --link selenium-hub --name=selenium-node selenium/node-chrome:3.141.59
f2b1f4236d39b4b248ce5bb10678c21762cef5cabda4c99e4aab8a956bd39f30

% rake monitoring
docker-compose -f load-testing/grafana/docker-compose.yaml stop
Stopping grafana_grafana_1  ... done
Stopping grafana_influxdb_1 ... done
docker-compose -f load-testing/grafana/docker-compose.yaml up -d
Starting grafana_influxdb_1 ... done
Starting grafana_grafana_1  ... done
```
