### PR TITLE
docker compose to bring up test infra locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,14 @@ gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfil
 
 ## Basic test run
 
-### Start selenium
+### Start test infra (influxdb, grafana, selenium)
 
 ```
-# start selenium
-docker run -d -p 4444:4444 --name=selenium --rm -v /dev/shm:/dev/shm selenium/standalone-chrome
+# start test infra
+docker-compose -f docker-compose-test-infra.yaml up -d
 ```
 
-### Start influxdb and grafana
-```
-# start influxdb and grafana
-cd load-testing/grafana
-docker-compose up -d
-```
-
-### Initial setup of influxdb (only needed on a new influxdb container)
+### Initial setup of influxdb and grafana (only needed on a new containers)
 ```
 # create database
 curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE ci_metrics"

--- a/docker-compose-test-infra.yaml
+++ b/docker-compose-test-infra.yaml
@@ -1,0 +1,37 @@
+version: '2'
+services:
+  influxdb:
+    image: influxdb:latest
+    ports:
+      - '8086:8086'
+    volumes:
+      - influxdb-storage:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=ci_metrics
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - '3000:3000'
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./grafana-provisioning/:/etc/grafana/provisioning
+    depends_on:
+      - influxdb
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+  hub:
+    image: selenium/hub:3.141
+    ports:
+      - '4444:4444'
+  chrome:
+    image: selenium/node-chrome:3.141
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - hub
+    environment:
+      HUB_HOST: hub
+volumes:
+  influxdb-storage:
+  grafana-storage:


### PR DESCRIPTION
Test infra needed to run the automated tests locally - selenium, influxdb, grafana. Bring these up with a single command - `docker-compose -f docker-compose-test-infra.yaml up -d`