### PR TITLE
fix for COVID19: .map-chart to .covid19-dashboard_counts

### DIFF
--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -408,7 +408,7 @@ module.exports = {
           css: '.covid19-dashboard_panel',
         },
         cards: {
-          css: '.map-chart',
+          css: '.covid19-dashboard_counts',
         },
       },
       covid19: {
@@ -416,7 +416,7 @@ module.exports = {
           css: '.covid19-dashboard_panel',
         },
         cards: {
-          css: '.map-chart',
+          css: '.covid19-dashboard_counts',
         },
       },
     };


### PR DESCRIPTION
The `.map-chart` element is not displayed when the environment is not set up with a mapbox token. Not sure why this only started failing now

### Bug Fixes
- Fix for COVID19: replace ".map-chart" with ".covid19-dashboard_counts" in homepage test
