### PR TITLE
chore(qa): Allow override of the google dynamic project

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -363,6 +363,9 @@ exitCode=0
 
 # set required vars
 export NAMESPACE="$namespaceName"
+if [[ "$testedEnv" == "ci-env-1.planx-pla.net" ]]; then
+  export GCLOUD_DYNAMIC_PROJECT="gen3qa-ci-env-1-279903"
+fi
 export testedEnv="$testedEnv"
 
 if [ "$selectedTest" == "all" ]; then

--- a/services/apis/fence/fenceProps.js
+++ b/services/apis/fence/fenceProps.js
@@ -476,7 +476,7 @@ module.exports = {
     // -has a parent organization:            false
     // -has service acct with invalid type:   false
     // -has a service acct with key:          false
-    id: 'gen3qa-NAMESPACE',
+    id: process.env.GCLOUD_DYNAMIC_PROJECT !== undefined ? process.env.GCLOUD_DYNAMIC_PROJECT : 'gen3qa-NAMESPACE',
     // id: 'gen3qa-validationjobtest',
     serviceAccountEmail: 'service-account@gen3qa-NAMESPACE.iam.gserviceaccount.com',
     defaultIsValidGCP: true,


### PR DESCRIPTION
New CI environments might not have unique google cloud project IDs, hence, we need to be able to override the `googleProjectDynamic .id` parameter through an environment variable.

Ideally the mapping of CI environments and their respective unique IDs must be placed in a separate file so we don't end up with multiple IF statements. This code is a short-term solution for to move forward with some experiments in `qaplanetv2`.