### PR TITLE
chore(qa): data-portal PRs should focus on GUI tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -266,6 +266,13 @@ else
   echo "INFO: enabling Centralized Auth tests for $service"
 fi
 
+# Focus on GUI tests for data-portal
+if [[ "$service" == "data-portal" ]]; then
+  echo "INFO: disabling tests involving RESTful APIs & Gen3 CLI / Batch operations for $service"
+  donot '@metadataIngestion'
+  donot '@batch'
+fi
+
 echo "Checking kubernetes for optional services to test"
 if ! (g3kubectl get pods --no-headers -l app=spark | grep spark) > /dev/null 2>&1; then
   donot '@etl'


### PR DESCRIPTION
Disabling a couple of RESTful API & batch processing tests for data-portal PRs to speed up the CI checks for that repo.