### PR TITLE
task(RAS Auth N): Improve aud/scope checks and add refresh token scenario

### DIFF
--- a/suites/apis/rasIntegrationTest.js
+++ b/suites/apis/rasIntegrationTest.js
@@ -155,7 +155,6 @@ Scenario('Refresh the access token with the refresh_token obtained through the O
 
   // decode JWT / Access Token
   const accessTokenJson = parseJwt(refreshAccessTokenOutputJson.access_token);
-  expect(accessTokenJson.aud).to.include('ga4gh_passport_v1');
   expect(accessTokenJson.scope).to.include('ga4gh_passport_v1');
 });
 

--- a/suites/apis/rasIntegrationTest.js
+++ b/suites/apis/rasIntegrationTest.js
@@ -121,6 +121,11 @@ Scenario('Use client creds from RAS Test User 1 and auth code to obtain access t
   // decode JWT / Access Token
   const accessTokenJson = parseJwt(tokens.access_token);
 
+  // PXP-6552 - Also decode the id_token and check if the client id is in place
+  const idTokenJson = parseJwt(tokens.id_token);
+  expect(idTokenJson).to.have.property('aud');
+  expect(idTokenJson.aud).to.include(I.cache.rasUser1ClientId);
+
   // run curl with access token and assert the claim is in place
   const userInfoOutputCmd = `curl -H "Authorization: bearer ${tokens.access_token}" https://${process.env.HOSTNAME}/user/user`;
   const userInfoOutput = bash.runCommand(userInfoOutputCmd);

--- a/suites/apis/rasIntegrationTest.js
+++ b/suites/apis/rasIntegrationTest.js
@@ -137,8 +137,8 @@ Scenario('Use client creds from RAS Test User 1 and auth code to obtain access t
 
   console.log(`access token audience: ${accessTokenJson.aud}`);
   console.log(`access token scope: ${accessTokenJson.scope}`);
-  expect(accessTokenJson.aud).to.include('ga4gh_passport_v1');
   expect(accessTokenJson.scope).to.include('ga4gh_passport_v1');
+  expect(accessTokenJson.scope).to.include('openid');
 });
 
 Scenario('Refresh the access token with the refresh_token obtained through the OIDC bootstrapping for RAS Test User 1 @rasAuthN', async (I) => {
@@ -230,5 +230,4 @@ Scenario('Use client creds for RAS Test User 2 and auth code to obtain access to
   console.log(`access token audience: ${accessTokenJson.aud}`);
   console.log(`access token scope: ${accessTokenJson.scope}`);
   expect(accessTokenJson.aud).to.not.include('ga4gh_passport_v1');
-  expect(accessTokenJson.scope).to.not.include('ga4gh_passport_v1');
 });


### PR DESCRIPTION
Addressing items from TODO list:
```
TODO: Run curl with access token and assert the claim is in place
TODO: Check if ga4gh_passport_v1 shows up inside both the aud & scope blocks of the access token
TODO: Check userinfo output (/user/user) using access token in addition to the browser check
TODO: Try to renew the access token through a refresh token
```