### PR TITLE
Revert "chore(qa): Temporarily disable ras tests due to issues with credentias"

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -222,7 +222,7 @@ runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 runTestsIfServiceVersion "@indexing" "portal" "2.26.0" "2020.05"
-# runTestsIfServiceVersion "@rasAuthN" "fence" "4.22.1" "2020.09"
+runTestsIfServiceVersion "@rasAuthN" "fence" "4.22.1" "2020.09"
 runTestsIfServiceVersion "@cleverSafe" "fence" "4.22.4" "2020.09"
 
 # environments that use DCF features
@@ -246,9 +246,6 @@ donot '@fail'
 
 # Do not run batch processing tests
 donot '@batch'
-
-# Temporarily disabling ras tests
-donot '@rasAuthN'
 
 #
 # Google Data Access tests are only required for some envs


### PR DESCRIPTION
The credentials have been restored. Let us re-enable this test suite.

Reverts uc-cdis/gen3-qa#450