### PR TITLE
chore(qa): Enable RAS tests just for some repos

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -222,7 +222,6 @@ runTestsIfServiceVersion "@dbgapSyncing" "fence" "3.0.0"
 runTestsIfServiceVersion "@indexRecordConsentCodes" "sheepdog" "1.1.13"
 runTestsIfServiceVersion "@coreMetadataPage" "portal" "2.20.8"
 runTestsIfServiceVersion "@indexing" "portal" "2.26.0" "2020.05"
-runTestsIfServiceVersion "@rasAuthN" "fence" "4.22.1" "2020.09"
 runTestsIfServiceVersion "@cleverSafe" "fence" "4.22.4" "2020.09"
 
 # environments that use DCF features
@@ -259,6 +258,21 @@ else
   # Run tests including google backend
   #
   echo "INFO: enabling Google Data Access tests for $service"
+fi
+
+#
+# RAS AuthN Integration tests are only required for some repos
+#
+if [[ "$isGen3Release" != "true" && "$service" != "gen3-qa" && "$service" != "fence" && "$service" == "cdis-manifest" ]]; then
+  # disable ras tests
+  echo "INFO: disabling RAS AuthN Integration tests for $service"
+  donot '@rasAuthN'
+else
+  #
+  # Run tests including RAS AuthN Integration tests
+  #
+  runTestsIfServiceVersion "@rasAuthN" "fence" "4.22.1" "2020.09"
+  echo "INFO: enabling RAS AuthN Integration tests for $service"
 fi
 
 # TODO: eventually enable for all services, but need arborist and fence updates first

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -263,7 +263,7 @@ fi
 #
 # RAS AuthN Integration tests are only required for some repos
 #
-if [[ "$isGen3Release" != "true" && "$service" != "gen3-qa" && "$service" != "fence" && "$service" == "cdis-manifest" ]]; then
+if [[ "$isGen3Release" != "true" && "$service" != "gen3-qa" && "$service" != "fence" && "$service" != "cdis-manifest" ]]; then
   # disable ras tests
   echo "INFO: disabling RAS AuthN Integration tests for $service"
   donot '@rasAuthN'

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -263,7 +263,7 @@ fi
 #
 # RAS AuthN Integration tests are only required for some repos
 #
-if [[ "$isGen3Release" != "true" && "$service" != "gen3-qa" && "$service" != "fence" && "$service" != "cdis-manifest" ]]; then
+if [[ "$isGen3Release" != "true" && "$service" != "gen3-qa" && "$service" != "fence" && "$service" != "cdis-manifest" && "$service" != "gitops-qa" && "$service" != "cloud-automation" && "$service" != "gitops-dev" ]]; then
   # disable ras tests
   echo "INFO: disabling RAS AuthN Integration tests for $service"
   donot '@rasAuthN'


### PR DESCRIPTION
Enable RAS AuthN tests for:
- `gen3-release` labeled PRs
- `gen3-qa`
- `fence` and 
- `cdis-manifest`