### PR TITLE
chore(qa): Additional debugging line for the Data File Upload test

### DIFF
--- a/utils/nodes.js
+++ b/utils/nodes.js
@@ -352,6 +352,7 @@ module.exports = {
         }
       } catch (err) {
         console.error(`WARN: Failed to check for the presence of the submitter_id property in metadata block ${prop}`, err);
+        console.error(`Here is the full metadata obj: ${metadata}`);
       }
     }
     metadata.data.core_metadata_collections = {

--- a/utils/nodes.js
+++ b/utils/nodes.js
@@ -352,7 +352,7 @@ module.exports = {
         }
       } catch (err) {
         console.error(`WARN: Failed to check for the presence of the submitter_id property in metadata block ${prop}`, err);
-        console.error(`Here is the full metadata obj: ${metadata}`);
+        console.error(`Here is the full metadata obj: ${JSON.stringify(metadata)}`);
       }
     }
     metadata.data.core_metadata_collections = {


### PR DESCRIPTION
Every property in `metadata.data` should all have a `submitter_id`.
For some mysterious reason, intermittently, one of the properties under the loop ends up being `null`.

Let us log the whole `metadata` obj along with the warning msg for further debugging.