### PR TITLE
fix(bucket-manifest-ci): fix sort function's syntax

### DIFF
--- a/suites/batch/GoogleBucketManifestGenerationTest.js
+++ b/suites/batch/GoogleBucketManifestGenerationTest.js
@@ -139,7 +139,7 @@ Scenario('Generate bucket manifest from s3 bucket @googleStorage @batch @bucketM
   let bucketManifestTSV = tsv.parse(bucketManifestContentsRaw);
   console.log(`bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
-  bucketManifestTSV = bucketManifestTSV.sort(( a, b ) => a.size - b.size);
+  bucketManifestTSV = bucketManifestTSV.sort((a, b) => a.size - b.size);
   console.log(`sorted bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
   // Final assertions

--- a/suites/batch/GoogleBucketManifestGenerationTest.js
+++ b/suites/batch/GoogleBucketManifestGenerationTest.js
@@ -139,7 +139,7 @@ Scenario('Generate bucket manifest from s3 bucket @googleStorage @batch @bucketM
   let bucketManifestTSV = tsv.parse(bucketManifestContentsRaw);
   console.log(`bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
-  bucketManifestTSV = bucketManifestTSV.sort(({ a, b }) => a.size - b.size);
+  bucketManifestTSV = bucketManifestTSV.sort(( a, b ) => a.size - b.size);
   console.log(`sorted bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
   // Final assertions

--- a/suites/batch/S3BucketManifestGenerationTest.js
+++ b/suites/batch/S3BucketManifestGenerationTest.js
@@ -139,7 +139,7 @@ Scenario('Generate bucket manifest from s3 bucket @amazonS3 @batch @bucketManife
   let bucketManifestTSV = tsv.parse(bucketManifestContentsRaw);
   console.log(`bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
-  bucketManifestTSV = bucketManifestTSV.sort(( a, b ) => a.size - b.size);
+  bucketManifestTSV = bucketManifestTSV.sort((a, b) => a.size - b.size);
   console.log(`sorted bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
   // Final assertions

--- a/suites/batch/S3BucketManifestGenerationTest.js
+++ b/suites/batch/S3BucketManifestGenerationTest.js
@@ -139,7 +139,7 @@ Scenario('Generate bucket manifest from s3 bucket @amazonS3 @batch @bucketManife
   let bucketManifestTSV = tsv.parse(bucketManifestContentsRaw);
   console.log(`bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
-  bucketManifestTSV = bucketManifestTSV.sort(({ a, b }) => a.size - b.size);
+  bucketManifestTSV = bucketManifestTSV.sort(( a, b ) => a.size - b.size);
   console.log(`sorted bucketManifestTSV: ${JSON.stringify(bucketManifestTSV)}`);
 
   // Final assertions


### PR DESCRIPTION
The Codeceptjs 3 automation accidentally surrounded the `sort` function arguments with the `{}` notation.
🤦 