### PR TITLE
chore(qa): Better error handling for empty output folder

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -436,11 +436,16 @@ fi
 # When zero tests are executed, a results*.xml file is produced containing a tests="0" counter
 # e.g., output/result57f4d8778c4987bda6a1790eaa703782.xml
 # <testsuites name="Mocha Tests" time="0.0000" tests="0" failures="0">
-ls -ilha output/result*.xml
-cat output/result*.xml  | head -n2 | sed -n -e 's/^<testsuites.*\(tests\=.*\) failures.*/\1/p'
+[ "$(ls -A output)" ] && ls output/result*.xml || echo "Warn: there are no output/result-*.xml files to parse"
+
 set +e
+
+cat output/result*.xml  | head -n2 | sed -n -e 's/^<testsuites.*\(tests\=.*\) failures.*/\1/p'
+
 zeroTests=$(cat output/result*.xml  | head -n2 | sed -n -e 's/^<testsuites.*\(tests\=.*\) failures.*/\1/p' | grep "tests=\"0\"")
+
 set -e
+
 if [ -n "$zeroTests" ]; then
   echo "No tests have been executed, aborting PR check..."
   npm test -- --verbose suites/fail.js


### PR DESCRIPTION
Seeing some recurrent failures in a few PRs showing:
```
+ ls output/*-testsuite.xml
ls: cannot access 'output/*-testsuite.xml': No such file or directory
```
This change should improve the error handling to force a proper PR check failure.