### PR TITLE
chore(qa): Setting kubeconfig declration accordingly

### DIFF
--- a/utils/commanders/sshk8s.js
+++ b/utils/commanders/sshk8s.js
@@ -27,24 +27,16 @@ class SshK8s extends Base {
     cleanResult = cleanResult || clean; // eslint-disable-line no-param-reassign
     const namespace = process.env.NAMESPACE;
     const commonsUser = userFromNamespace(namespace);
+    const kubeconfigPath = process.env.vpc_name === undefined ? 'Gen3Secrets' : process.env.vpc_name;
+    const kubeconfigDeclaration = process.env.RUNNING_LOCAL === 'true' ? `export KUBECONFIG=/home/${process.env.NAMESPACE}/${kubeconfigPath}/kubeconfig;` : '';
     if (service === undefined) {
-      return cleanResult(execSync(`ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; source ~/.bashrc; ${cmd}'`,
+      return cleanResult(execSync(`ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; source ~/.bashrc; ${kubeconfigDeclaration} ${cmd}'`,
         { shell: '/bin/bash' }).toString('utf8'));
     }
-    let result = '';
-    if (process.env.RUNNING_LOCAL === 'true') {
-      const kubeconfigPath = process.env.vpc_name === undefined ? 'Gen3Secrets' : process.env.vpc_name;
-      result = cleanResult(execSync(
-        `ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; export KUBECONFIG=/home/${process.env.NAMESPACE}/${kubeconfigPath}/kubeconfig; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
-        { shell: '/bin/sh' },
-      ).toString('utf8'));
-    } else {
-      result = cleanResult(execSync(
-        `ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
-        { shell: '/bin/sh' },
-      ).toString('utf8'));
-    }
-    return result;
+    return cleanResult(execSync(
+      `ssh ${commonsUser}@cdistest_dev.csoc 'export GEN3_HOME=$HOME/cloud-automation && source "$GEN3_HOME/gen3/gen3setup.sh"; ${kubeconfigDeclaration} g3kubectl exec $(gen3 pod ${service} ${namespace}) -- ${cmd}'`,
+      { shell: '/bin/sh' },
+    ).toString('utf8'));
   }
 }
 


### PR DESCRIPTION
We need to set the kubeconfig declaration in case we need to override the kubeconfig path (some environments are still using the legacy kubeconfig path instead of adopting the new `Gen3Secrets` folder).

This `export KUBECONFIG` is necessary whenever we are running any of the following scenarios:
- While running a gen3 cli command inside the admin vm  => `(service === undefined)`
- and Running a command inside a kubernetes pod