### PR TITLE
fix(qa): influxDB status nodes check

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -32,7 +32,7 @@ module.exports = function () {
     const resp = await fetch('http://selenium-hub:4444/status');
     const respJson = await resp.json();
     let sessionCount = 0;
-    const { nodes } = respJson;
+    const { nodes } = respJson.value;
     if (nodes.length > 0) {
       nodes.forEach((node) => {
         node.slots.forEach((slot) => {


### PR DESCRIPTION
Fixing this error:
```
(node:23173) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at EventEmitter.<anonymous> (/Users/marcelocostarodrigues/workspace/gen3-qa/hooks/test_results.js:36:15)
```