### PR TITLE
chore(qa): Move etl es index checks outside the scenario blocks

### DIFF
--- a/services/apis/etl/etlSequences.js
+++ b/services/apis/etl/etlSequences.js
@@ -8,9 +8,7 @@ const { expect } = chai;
 chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
-const etlQuestions = require('./etlQuestions.js');
 const etlTasks = require('./etlTasks.js');
-const etlProps = require('./etlProps.js');
 const sheepdogTask = require('../sheepdog/sheepdogTasks.js');
 
 /**
@@ -21,13 +19,6 @@ module.exports = {
    * Running ETL first time. Expect no alias at the beginning and have alias at the end
    */
   runETLFirstTime() {
-    etlProps.aliases.forEach(async (alias) => {
-      const index = etlTasks.getIndexFromAlias(alias);
-      if (index !== 'error') {
-        etlTasks.deleteIndices(index);
-        expect(etlTasks.existAlias(alias), 'Fails to delete alias').to.equal(false);
-      }
-    });
     expect(etlTasks.runETLJob()).to.equal(true);
   },
 
@@ -37,12 +28,5 @@ module.exports = {
   runETLSecondTime() {
     sheepdogTask.runGenTestData(1);
     expect(etlTasks.runETLJob()).to.equal(true);
-    etlProps.aliases.forEach((alias) => {
-      if (etlTasks.existAlias(alias)) {
-        const index = etlTasks.getIndexFromAlias(alias);
-        console.error(index);
-        etlQuestions.hasVersionIncreased(index, 0);
-      }
-    });
   },
 };

--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -1,13 +1,33 @@
 Feature('ETL');
 
+BeforeSuite(async ({ etl }) => {
+  etl.props.aliases.forEach(async (alias) => {
+    const index = etl.do.getIndexFromAlias(alias);
+    if (index !== 'error') {
+      etl.do.deleteIndices(index);
+      expect(etl.do.existAlias(alias), 'Fails to delete alias').to.equal(false);
+    }
+  });
+});
+
 Scenario('run ETL first time @etl', async ({ etl }) => {
   console.log(`${new Date()}: Before run ETL first time`);
   await etl.complete.runETLFirstTime();
   console.log(`${new Date()}: After run ETL first time`);
-}).retry(1);
+});
 
 Scenario('run ETL second time @etl', async ({ etl }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await etl.complete.runETLSecondTime();
   console.log(`${new Date()}: After run ETL second time`);
-}).retry(1);
+});
+
+AfterSuite(async ({ etl }) => {
+  etl.props.aliases.forEach((alias) => {
+    if (etl.do.existAlias(alias)) {
+      const index = etl.do.getIndexFromAlias(alias);
+      console.error(index);
+      etl.ask.hasVersionIncreased(index, 0);
+    }
+  });
+});


### PR DESCRIPTION
Trying to avoid the intermittent failure that is becoming quite recurrent recently:
```
ETL "after each" hook: finalize codeceptjs for "run ETL second time @etl" – "after each" hook: finalize codeceptjs for "run ETL second time @etl"
<1s
Error
org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 66987dd54945840faf51e649e311a9d2 
Build info: version: '4.0.0-beta-1', 
revision: '(prerelease)-4610dcfb35' 
System info: host: 'selenium-hub-59dddf6c46-vzkwc', 
ip: '***', 
os.name: 'Linux', 
os.arch: 'amd64', 
os.version: '***', 
java.version: '1.8.0_275' 
Driver info: driver.version: unknown
```