### PR TITLE
fix(qa): Fix ETL tests

### DIFF
--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -17,7 +17,7 @@ BeforeSuite(async ({ etl }) => {
 
 Scenario('run ETL first time @etl', async () => {
   console.log(`${new Date()}: Before run ETL first time`);
-  await bash.runJob('etl');
+  await bash.runJob('etl', '', false);
   await checkPod('etl', 'gen3job,job-name=etl');
   console.log(`${new Date()}: After run ETL first time`);
 });
@@ -25,7 +25,7 @@ Scenario('run ETL first time @etl', async () => {
 Scenario('run ETL second time @etl', async ({ sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await sheepdog.do.runGenTestData(1);
-  await bash.runJob('etl');
+  await bash.runJob('etl', '', false);
   await checkPod('etl', 'gen3job,job-name=etl');
   console.log(`${new Date()}: After run ETL second time`);
 });

--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -1,5 +1,10 @@
 Feature('ETL');
 
+const { Bash } = require('../../utils/bash.js');
+const { checkPod } = require('../../utils/apiUtil.js');
+
+const bash = new Bash();
+
 BeforeSuite(async ({ etl }) => {
   etl.props.aliases.forEach(async (alias) => {
     const index = etl.do.getIndexFromAlias(alias);
@@ -10,15 +15,18 @@ BeforeSuite(async ({ etl }) => {
   });
 });
 
-Scenario('run ETL first time @etl', async ({ etl }) => {
+Scenario('run ETL first time @etl', async () => {
   console.log(`${new Date()}: Before run ETL first time`);
-  await etl.complete.runETLFirstTime();
+  await bash.runJob('etl');
+  await checkPod('etl', 'gen3job,job-name=etl');
   console.log(`${new Date()}: After run ETL first time`);
 });
 
-Scenario('run ETL second time @etl', async ({ etl }) => {
+Scenario('run ETL second time @etl', async ({ sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
-  await etl.complete.runETLSecondTime();
+  await sheepdog.do.runGenTestData(1);
+  await bash.runJob('etl');
+  await checkPod('etl', 'gen3job,job-name=etl');
   console.log(`${new Date()}: After run ETL second time`);
 });
 

--- a/suites/portal/landingPageButtonsTest.js
+++ b/suites/portal/landingPageButtonsTest.js
@@ -2,10 +2,10 @@
  Automated tests for Landing Page buttons (PXP-6216)
  This test plan assumes the presence of one or more default
  landing page with the following cards:
-  1. Define Data Field (redirects user to #hostname/DD)
-  2. Explore Data (redirects user to #hostname/explorer)
-  3. Access Data (redirects user to #hotname/query)
-  4. Analyze Data (redirects user to #hostname/workspace)
+  1. Define Data Field (redirects user to /DD)
+  2. Explore Data (redirects user to /explorer or /files)
+  3. Access Data (redirects user to /query)
+  4. Analyze Data (redirects user to /workspace)
 */
 Feature('Landing page buttons');
 
@@ -20,19 +20,19 @@ Scenario('Navigate to the landing page and click on buttons @landing', async ({ 
   const buttons = [
     {
       text: 'Learn more',
-      expectedUrl: 'DD',
+      expectedUrls: ['DD'],
     },
     {
       text: 'Explore data',
-      expectedUrl: 'explorer',
+      expectedUrls: ['explorer', 'files'],
     },
     {
       text: 'Query data',
-      expectedUrl: 'query',
+      expectedUrls: ['query'],
     },
     {
       text: 'Run analysis',
-      expectedUrl: 'workspace',
+      expectedUrls: ['workspace'],
     },
   ];
 
@@ -44,18 +44,24 @@ Scenario('Navigate to the landing page and click on buttons @landing', async ({ 
     I.waitForElement({ css: '.index-button-bar' }, 10);
     const btExists = await tryTo(() => I.seeElement({ xpath: `//button[contains(text(), '${button.text}')]` })); // eslint-disable-line no-undef
     if (btExists) {
-      const assertionFailureMsg = `button ${button.text} did not redirect user to expected url ${button.expectedUrl}.`;
+      const assertionFailureMsg = `button ${button.text} did not redirect user to one of the expected urls ${button.expectedUrls}.`;
       I.click({ xpath: `//button[contains(text(), '${button.text}')]` });
       await sleepMS(500);
       const theUrl = await I.grabCurrentUrl();
+
+      const validURLs = [];
+      button.expectedUrls.forEach((expectedUrl) => {
+        validURLs.push(`https://${process.env.HOSTNAME}/${expectedUrl}`);
+      });
+
       expect(
-        theUrl,
+        validURLs,
         assertionFailureMsg,
-      ).to.be.equal(`https://${process.env.HOSTNAME}/${button.expectedUrl}`);
+      ).to.include(theUrl);
     } else {
       console.log(`Button ${button.text} does not exist on this landing page. Skipping check...`);
     }
     // Go back to the landing page and try to find / click on the buttons again
     I.amOnPage('/');
   }
-}).retry(2);
+}).retry(1);


### PR DESCRIPTION
Our ETL test is based on a background execution of a k8s job (triggered by the `gen3 job run etl` command), which results in an idle thread that pauses everything for longer than 300 seconds, the selenium hub is reaping / terminating our session before the test is completed so CodeceptJS cannot gracefully terminate the session (and that only happens if there’s too much computing based on the size of the dictionary / number of nodes, etc).
This change will avoid the long pause and it will, instead, keep polling the pod for the etl results.

### Improvements
- Improving ETL tests logic to run some polling to check the state of the ETL pod / k8s job.