### PR TITLE
Fix/increase max attempts for etl polling

### DIFF
--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -18,7 +18,7 @@ BeforeSuite(async ({ etl }) => {
 Scenario('run ETL first time @etl', async () => {
   console.log(`${new Date()}: Before run ETL first time`);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl');
+  await checkPod('etl', 'gen3job,job-name=etl', params = { nAttempts: 18, ignoreFailure: false });
   console.log(`${new Date()}: After run ETL first time`);
 });
 
@@ -26,7 +26,7 @@ Scenario('run ETL second time @etl', async ({ sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await sheepdog.do.runGenTestData(1);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl');
+  await checkPod('etl', 'gen3job,job-name=etl', params = { nAttempts: 18, ignoreFailure: false });
   console.log(`${new Date()}: After run ETL second time`);
 });
 

--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -18,7 +18,7 @@ BeforeSuite(async ({ etl }) => {
 Scenario('run ETL first time @etl', async () => {
   console.log(`${new Date()}: Before run ETL first time`);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl', params = { nAttempts: 18, ignoreFailure: false });
+  await checkPod('etl', 'gen3job,job-name=etl', { nAttempts: 18, ignoreFailure: false });
   console.log(`${new Date()}: After run ETL first time`);
 });
 
@@ -26,7 +26,7 @@ Scenario('run ETL second time @etl', async ({ sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await sheepdog.do.runGenTestData(1);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl', params = { nAttempts: 18, ignoreFailure: false });
+  await checkPod('etl', 'gen3job,job-name=etl', { nAttempts: 18, ignoreFailure: false });
   console.log(`${new Date()}: After run ETL second time`);
 });
 


### PR DESCRIPTION
Trying 18 polling checks instead of just 9 (with a `sleep 10` interval between attempts).