### PR TITLE
fix(qa): Fix logic to run sheepdog test with consent codes

### DIFF
--- a/suites/sheepdogAndPeregrine/submitAndQueryNodesTest.js
+++ b/suites/sheepdogAndPeregrine/submitAndQueryNodesTest.js
@@ -207,7 +207,7 @@ Scenario('submit data node with consent codes @indexRecordConsentCodes', async (
     `${indexd.props.endpoints.get}`,
   );
 
-  listOfIndexdRecords.data.records.forEach(async ( record ) => {
+  listOfIndexdRecords.data.records.forEach(async (record) => {
     console.log(record.did);
     await indexd.do.deleteFile({ did: record.did });
   });

--- a/suites/sheepdogAndPeregrine/submitAndQueryNodesTest.js
+++ b/suites/sheepdogAndPeregrine/submitAndQueryNodesTest.js
@@ -207,7 +207,7 @@ Scenario('submit data node with consent codes @indexRecordConsentCodes', async (
     `${indexd.props.endpoints.get}`,
   );
 
-  listOfIndexdRecords.data.records.forEach(async ({ record }) => {
+  listOfIndexdRecords.data.records.forEach(async ( record ) => {
     console.log(record.did);
     await indexd.do.deleteFile({ did: record.did });
   });


### PR DESCRIPTION
Address the following failure:
```
SubmitAndQueryNodesTest submit data node with consent codes @indexRecordConsentCodes – submit data node with consent codes @indexRecordConsentCodes
2s
Error
expected [ '/programs/jnkns/projects/jenkins' ] to be a superset of [ '/consents/CC1', '/consents/CC2' ]
Stacktrace
AssertionError: expected [ '/programs/jnkns/projects/jenkins' ] to be a superset of [ '/consents/CC1', '/consents/CC2' ]
at Proxy.<anonymous> (node_modules/chai/lib/chai/core/assertions.js:3094:10)
at Proxy.methodWrapper (node_modules/chai/lib/chai/utils/addMethod.js:57:25)
```