### PR TITLE
fix(qa): Keep Selenium session alive during ETL tests

### DIFF
--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -15,18 +15,18 @@ BeforeSuite(async ({ etl }) => {
   });
 });
 
-Scenario('run ETL first time @etl', async () => {
+Scenario('run ETL first time @etl', async ({ I }) => {
   console.log(`${new Date()}: Before run ETL first time`);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl', { nAttempts: 30, ignoreFailure: false });
+  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 30, ignoreFailure: false, keepSessionAlive: true });
   console.log(`${new Date()}: After run ETL first time`);
 });
 
-Scenario('run ETL second time @etl', async ({ sheepdog }) => {
+Scenario('run ETL second time @etl', async ({ I, sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await sheepdog.do.runGenTestData(1);
   await bash.runJob('etl', '', false);
-  await checkPod('etl', 'gen3job,job-name=etl', { nAttempts: 30, ignoreFailure: false });
+  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 30, ignoreFailure: false, keepSessionAlive: true });
   console.log(`${new Date()}: After run ETL second time`);
 });
 

--- a/suites/apis/metadataIngestionTest.js
+++ b/suites/apis/metadataIngestionTest.js
@@ -74,7 +74,7 @@ async function checkMetadataServiceEntry(I, expectedResult, authHeader) {
 }
 
 async function feedTSVIntoMetadataIngestion(I, fence, uid, authHeader, expectedResult) {
-  await checkPod('get-dbgap-metadata', 'sowerjob');
+  await checkPod(I, 'get-dbgap-metadata', 'sowerjob');
 
   let jobOutput = ''; let jobLogsURL = ''; let preSignedURL = '';
   try {
@@ -190,7 +190,7 @@ Scenario('Dispatch ingest-metadata-manifest sower job with simple tsv and verify
     `Should have triggered the ${sowerJobName} sower job`,
   ).to.have.property('status', 200);
 
-  await checkPod(sowerJobName, 'sowerjob');
+  await checkPod(I, sowerJobName, 'sowerjob');
   const metadataServiceEntry = await checkMetadataServiceEntry(
     I,
     expectedResults.ingest_metadata_manifest.testGUID,

--- a/suites/batch/GoogleBucketManifestGenerationTest.js
+++ b/suites/batch/GoogleBucketManifestGenerationTest.js
@@ -101,7 +101,7 @@ Scenario('Generate bucket manifest from s3 bucket @googleStorage @batch @bucketM
   console.log(`short jobId: ${jobId}`);
 
   await sleepMS(20000);
-  await checkPod('google-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
+  await checkPod(I, 'google-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
 
   const bucketManifestList = await bash.runCommand(`
     gen3 gcp-bucket-manifest list | xargs -i echo "{} "

--- a/suites/batch/S3BucketManifestGenerationTest.js
+++ b/suites/batch/S3BucketManifestGenerationTest.js
@@ -92,7 +92,7 @@ Scenario('Generate bucket manifest from s3 bucket @amazonS3 @batch @bucketManife
   console.log('gen3 bucket-manifest process initiated. Waiting for infrastructure provisioning...');
 
   await sleepMS(20000);
-  await checkPod('aws-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
+  await checkPod(I, 'aws-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
 
   const bucketManifestList = await bash.runCommand(`
     gen3 bucket-manifest --list | xargs -i echo "{} "

--- a/suites/google/googleDataAccessTest.js
+++ b/suites/google/googleDataAccessTest.js
@@ -160,7 +160,7 @@ BeforeSuite(async ({ indexd, fence, google }) => {
   });
 });
 
-AfterSuite(async ({ indexd }) => {
+AfterSuite(async ({ I, indexd }) => {
   console.log('Removing indexd files used to test signed urls');
   await indexd.do.deleteFileIndices(Object.values(indexed_files));
 

--- a/suites/google/googleDataAccessTest.js
+++ b/suites/google/googleDataAccessTest.js
@@ -65,10 +65,10 @@ const indexed_files = {
   },
 };
 
-const googleDataAccessTestSteps = async (fence, user, google, files, paramsQA1, paramsTest1, paramsQA2, paramsTest2) => {
+const googleDataAccessTestSteps = async (I, fence, user, google, files, paramsQA1, paramsTest1, paramsQA2, paramsTest2) => {
   console.log('*** RUN USERSYNC JOB ***');
   bash.runJob('usersync', args = 'FORCE true');
-  await checkPod('usersync', 'gen3job,job-name=usersync');
+  await checkPod(I, 'usersync', 'gen3job,job-name=usersync');
 
   console.log('*** UNLINK AND LINK GOOGLE ACCOUNT ***');
   await fence.complete.forceUnlinkGoogleAcct(user);
@@ -109,7 +109,7 @@ const googleDataAccessTestSteps = async (fence, user, google, files, paramsQA1, 
   console.log(`*** RUN USERYAML WITH ${Commons.userAccessFiles.newUserAccessFile2} ***`);
   Commons.setUserYaml(Commons.userAccessFiles.newUserAccessFile2);
   bash.runJob('useryaml');
-  await checkPod('useryaml', 'gen3job,job-name=useryaml');
+  await checkPod(I, 'useryaml', 'gen3job,job-name=useryaml');
   await sleepMS(30000);
 
   console.log(`*** RE-CREATE TEMP GOOGLE CREDS FOR USER ${user.username} AND SAVE TO TEMP FILE ***`);
@@ -166,13 +166,13 @@ AfterSuite(async ({ indexd }) => {
 
   console.log('Running usersync job');
   bash.runJob('usersync', args = 'FORCE true');
-  await checkPod('usersync', 'gen3job,job-name=usersync');
+  await checkPod(I, 'usersync', 'gen3job,job-name=usersync');
 });
 
 Scenario('Test Google Data Access User0 @reqGoogle @googleDataAccess @manual',
-  async ({ fence, users, google, files }) => {
+  async ({ I, fence, users, google, files }) => {
     const result = await googleDataAccessTestSteps(
-      fence, users.user0, google, files,
+      I, fence, users.user0, google, files,
       { nAttempts: 1, expectAccessDenied: false }, // paramsQA1
       { nAttempts: 3, expectAccessDenied: true }, // paramsTest1
       { nAttempts: 3, expectAccessDenied: true }, // paramsQA2
@@ -199,9 +199,9 @@ Scenario('Test Google Data Access User0 @reqGoogle @googleDataAccess @manual',
 );
 
 Scenario('Test Google Data Access User1 @reqGoogle @googleDataAccess @manual',
-  async ({ fence, users, google, files }) => {
+  async ({ I, fence, users, google, files }) => {
     const result = await googleDataAccessTestSteps(
-      fence, users.user1, google, files,
+      I, fence, users.user1, google, files,
       { nAttempts: 1, expectAccessDenied: false }, // paramsQA1
       { nAttempts: 1, expectAccessDenied: false }, // paramsTest1
       { nAttempts: 3, expectAccessDenied: true }, // paramsQA2
@@ -228,9 +228,9 @@ Scenario('Test Google Data Access User1 @reqGoogle @googleDataAccess @manual',
 );
 
 Scenario('Test Google Data Access User2 @reqGoogle @googleDataAccess',
-  async ({ fence, users, google, files }) => {
+  async ({ I, fence, users, google, files }) => {
     const result = await googleDataAccessTestSteps(
-      fence, users.user2, google, files,
+      I, fence, users.user2, google, files,
       { nAttempts: 3, expectAccessDenied: true }, // paramsQA1
       { nAttempts: 3, expectAccessDenied: true }, // paramsTest1
       { nAttempts: 1, expectAccessDenied: false }, // paramsQA2

--- a/suites/portal/indexingPageTest.js
+++ b/suites/portal/indexingPageTest.js
@@ -65,7 +65,7 @@ Scenario('Navigate to the indexing page and upload a test manifest @indexing', a
   I.attachFile('input[type=\'file\']', `manifest_${I.cache.UNIQUE_NUM}.tsv`);
   I.click({ xpath: 'xpath: //button[contains(text(), \'Index Files\')]' });
 
-  await checkPod('manifest-indexing', 'sowerjob');
+  await checkPod(I, 'manifest-indexing', 'sowerjob');
 
   const nAttempts = 12;
   for (let i = 0; i < nAttempts; i += 1) {
@@ -99,7 +99,7 @@ Scenario('Navigate to the indexing page and download a full indexd manifest @ind
   I.waitForElement({ css: '.indexing-page' }, 10);
   I.click({ xpath: 'xpath: //button[contains(text(), \'Download\')]' });
 
-  await checkPod('indexd-manifest', 'sowerjob');
+  await checkPod(I, 'indexd-manifest', 'sowerjob');
 
   const waitingThreshold = 60;
   console.log('Waiting for Green status DONE to show up on the page...');
@@ -135,7 +135,7 @@ Scenario('Navigate to the indexing page and upload an invalid manifest @indexing
   I.attachFile('input[type=\'file\']', `invalid_manifest_${I.cache.UNIQUE_NUM}.tsv`);
   I.click({ xpath: 'xpath: //button[contains(text(), \'Index Files\')]' });
 
-  await checkPod('manifest-indexing', 'sowerjob', { nAttempts: 5, ignoreFailure: true });
+  await checkPod(I, 'manifest-indexing', 'sowerjob', { nAttempts: 5, ignoreFailure: true });
 
   const nAttempts = 12;
   for (let i = 0; i < nAttempts; i += 1) {

--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -358,12 +358,27 @@ module.exports = {
    * @param {string} podName - name of the pod that must be found
    * @param {int} nAttempts - number of times the function should try to find the expected pod
    */
-  async checkPod(jobName, labelName, params = { nAttempts: 10, ignoreFailure: false }) {
+  async checkPod(
+    I,
+    jobName,
+    labelName,
+    params = {
+      nAttempts: 10,
+      ignoreFailure: false,
+      keepSessionAlive: false,
+    },
+  ) {
     let podFound = false;
     for (let i = 1; i < params.nAttempts; i += 1) {
       try {
         console.log(`waiting for ${jobName} job pod... - attempt ${i}`);
         await module.exports.sleepMS(10000);
+
+        // refresh page on the underlying chrome browser to force the Selenium session to stay alive
+        if (params.keepSessionAlive) {
+          I.refreshPage();
+        }
+
         const singleQuote = process.env.RUNNING_LOCAL === 'true' ? "\'\\'\'" : "'"; // eslint-disable-line quotes,no-useless-escape
         const podName = await bash.runCommand(`g3kubectl get pod --sort-by=.metadata.creationTimestamp -l app=${labelName} -o jsonpath="{.items[*].metadata.name}" | awk ${singleQuote}{print $NF}${singleQuote}`);
         console.log(`latest pod found: ${podName}`);


### PR DESCRIPTION
Conditional hack to force the Selenium session to stay alive while polling for k8s job results.