### PR TITLE
chore(qa): Ignore selenium hub metrics while running in prod

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -29,7 +29,7 @@ async function writeMetrics(measurement, test, currentRetry) {
 
   // selenium metrics
   let sessionCount = 0;
-  if (process.env.RUNNING_IN_PROD_TIER === "true") {
+  if (process.env.RUNNING_IN_PROD_TIER === 'true') {
     console.log('INFO: Running in prod-tier environment. Ignore selenium-hub metrics.');
   } else {
     const resp = await fetch('http://localhost:4444/status');

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -28,18 +28,23 @@ async function writeMetrics(measurement, test, currentRetry) {
   }
 
   // selenium metrics
-  const resp = await fetch('http://selenium-hub:4444/status');
-  const respJson = await resp.json();
   let sessionCount = 0;
-  const { nodes } = respJson.value;
-  if (nodes.length > 0) {
-    nodes.forEach((node) => {
-      node.slots.forEach((slot) => {
-        if (slot.session) {
-          sessionCount += 1;
-        }
+  if (process.env.RUNNING_IN_PROD_TIER === "true") {
+    console.log('INFO: Running in prod-tier environment. Ignore selenium-hub metrics.');
+  } else {
+    const resp = await fetch('http://localhost:4444/status');
+    const respJson = await resp.json();
+
+    const { nodes } = respJson.value;
+    if (nodes.length > 0) {
+      nodes.forEach((node) => {
+        node.slots.forEach((slot) => {
+          if (slot.session) {
+            sessionCount += 1;
+          }
+        });
       });
-    });
+    }
   }
 
   // logs


### PR DESCRIPTION
No need to gather selenium-hub metrics as the `gen3qa-run` CLI will trigger k8s jobs that will utilize a simple `selenium` side car container.