### PR TITLE
fix : fixing the homepage for midrc

### DIFF
--- a/services/portal/home/homeTasks.js
+++ b/services/portal/home/homeTasks.js
@@ -10,7 +10,7 @@ module.exports = {
   goToHomepage() {
     I.amOnPage(homeProps.path);
     console.log(`### ## testedEnv:${process.env.testedEnv}`);
-    if (process.env.testedEnv.includes('covid19') || process.env.testedEnv.includes('pandemicresponsecommons')) {
+    if (process.env.testedEnv.includes('covid19') || process.env.testedEnv.includes('pandemicresponsecommons')|| process.env.testedEnv.includes('midrc')) {
       I.refreshPage();
     }
     portal.seeProp(homeProps.ready_cue, 60);

--- a/services/portal/home/homeTasks.js
+++ b/services/portal/home/homeTasks.js
@@ -10,7 +10,7 @@ module.exports = {
   goToHomepage() {
     I.amOnPage(homeProps.path);
     console.log(`### ## testedEnv:${process.env.testedEnv}`);
-    if (process.env.testedEnv.includes('covid19') || process.env.testedEnv.includes('pandemicresponsecommons')|| process.env.testedEnv.includes('midrc')) {
+    if (process.env.testedEnv.includes('covid19') || process.env.testedEnv.includes('pandemicresponsecommons') || process.env.testedEnv.includes('midrc')) {
       I.refreshPage();
     }
     portal.seeProp(homeProps.ready_cue, 60);


### PR DESCRIPTION
As the MIDRC homepage takes more than 10sec to load, hence causing the tests to fail. 

Now the page will refresh itself