### PR TITLE
fix(qa): Bucket Manifest CI must keep the Selenium session alive

### DIFF
--- a/suites/batch/S3BucketManifestGenerationTest.js
+++ b/suites/batch/S3BucketManifestGenerationTest.js
@@ -92,7 +92,7 @@ Scenario('Generate bucket manifest from s3 bucket @amazonS3 @batch @bucketManife
   console.log('gen3 bucket-manifest process initiated. Waiting for infrastructure provisioning...');
 
   await sleepMS(20000);
-  await checkPod(I, 'aws-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
+  await checkPod(I, 'aws-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false, keepSessionAlive: true }); // eslint-disable-line no-undef
 
   const bucketManifestList = await bash.runCommand(`
     gen3 bucket-manifest --list | xargs -i echo "{} "


### PR DESCRIPTION
Quick fix to avoid this error:
```
-- FAILURES:

  1) S3 Bucket Manifest Generation
       "after each" hook: finalize codeceptjs for "Generate bucket manifest from s3 bucket @amazonS3 @batch @bucketManifest":
     unknown error: org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: cb91b4ff5f50d9d78ffbc667b3ea6983
```