### PR TITLE
chore(qa): Increase the number of retries for data upload pod checks

### DIFF
--- a/suites/portal/dataUploadTest.js
+++ b/suites/portal/dataUploadTest.js
@@ -45,7 +45,7 @@ const uploadFile = async function (I, dataUpload, indexd, sheepdog, nodes, fileO
     },
   };
 
-  await checkPod(I, 'indexing', 'ssjdispatcherjob', params = { nAttempts: 24, ignoreFailure: false }); // eslint-disable-line no-undef
+  await checkPod(I, 'indexing', 'ssjdispatcherjob', params = { nAttempts: 36, ignoreFailure: false, keepSessionAlive: true }); // eslint-disable-line no-undef
 
   await dataUpload.waitUploadFileUpdatedFromIndexdListener(indexd, fileNode);
 };


### PR DESCRIPTION
Sometimes the `indexing` pod takes longer to start, so the test is reaching its `checkPod` threshold for some PRs causing intermittent failures.
```
Error
Failed to obtain a successful phase check from the indexing job on attempt 23: Max number of attempts reached: 23

Stacktrace
Error: Failed to obtain a successful phase check from the indexing job on attempt 23: Max number of attempts reached: 23
at checkPod (utils/apiUtil.js:406:15)
at async uploadFile (suites/portal/dataUploadTest.js:48:3)
```


TODO: Find a way to fail fast when the `indexing` pod fails.
