### PR TITLE
chore(security): Address security alert related to node-forge lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4247,6 +4247,14 @@
       "dev": true,
       "requires": {
         "node-forge": "^0.9.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
+          "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
+          "dev": true
+        }
       }
     },
     "googleapis": {
@@ -4698,9 +4706,9 @@
       }
     },
     "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
     "htmlescape": {
@@ -6806,9 +6814,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
-      "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-ssh": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "nconf": "^0.10.0",
     "nock": "^12.0.3",
     "node-fetch": "^2.6.1",
+    "node-forge": ">=0.10.0",
     "node-ssh": "^7.0.1",
     "cli-progress": "^3.8.2",
     "prettier": "^1.19.1",


### PR DESCRIPTION
CVE-2020-7720
high severity
Vulnerable versions: < 0.10.0
Patched version: 0.10.0
The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function. Note: Version 0.10.0 is a breaking change removing the vulnerable functions.