### PR TITLE
chore(qa): Increase max retries for Data Upload Test

### DIFF
--- a/suites/portal/dataUploadTest.js
+++ b/suites/portal/dataUploadTest.js
@@ -45,7 +45,7 @@ const uploadFile = async function (I, dataUpload, indexd, sheepdog, nodes, fileO
     },
   };
 
-  await checkPod(I, 'indexing', 'ssjdispatcherjob', params = { nAttempts: 36, ignoreFailure: false, keepSessionAlive: true }); // eslint-disable-line no-undef
+  await checkPod(I, 'indexing', 'ssjdispatcherjob', params = { nAttempts: 40, ignoreFailure: false, keepSessionAlive: true }); // eslint-disable-line no-undef
 
   await dataUpload.waitUploadFileUpdatedFromIndexdListener(indexd, fileNode);
 };


### PR DESCRIPTION
Trying to avoid intermittent failures caused by slow indexing jobs (potentially due to 1-2 retries).