### PR TITLE
fix(bucket-manifest-test): Keep session alive as Selenium4 kills it after 5 minutes

### DIFF
--- a/suites/batch/GoogleBucketManifestGenerationTest.js
+++ b/suites/batch/GoogleBucketManifestGenerationTest.js
@@ -101,7 +101,7 @@ Scenario('Generate bucket manifest from s3 bucket @googleStorage @batch @bucketM
   console.log(`short jobId: ${jobId}`);
 
   await sleepMS(20000);
-  await checkPod(I, 'google-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false }); // eslint-disable-line no-undef
+  await checkPod(I, 'google-bucket-manifest', 'gen3job', params = { nAttempts: 100, ignoreFailure: false, keepSessionAlive: true }); // eslint-disable-line no-undef
 
   const bucketManifestList = await bash.runCommand(`
     gen3 gcp-bucket-manifest list | xargs -i echo "{} "


### PR DESCRIPTION
Prevents the failure below:
```
-- FAILURES:

  1) Google Bucket Manifest Generation
       "after each" hook: finalize codeceptjs for "Generate bucket manifest from s3 bucket @googleStorage @batch @bucketManifest":
     Unable to find handler for (DELETE) /session/63a1b858916c759391289149308f70c2
      at Object.getErrorFromResponseBody (node_modules/webdriver/build/utils.js:94:12)
      at WebDriverRequest._request (node_modules/webdriver/build/request.js:133:31)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at async Browser.wrapCommandFn (node_modules/@wdio/utils/build/shim.js:58:29)
```