### PR TITLE
chore(qa): Improve logic to capture failures with long-running tests and avoid false negatives

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -104,7 +104,7 @@ module.exports = function () {
     if (testResult === undefined) {
       // If there are any Selenium failures, we cannot let the test fail silently.
       // We need to force return an exit code 1.
-      throw new Error(`THE TEST RESULT IS UNDEFINED! ABORT ALL TESTS AND FAIL THIS PR.`);
+      throw new Error('THE TEST RESULT IS UNDEFINED! ABORT ALL TESTS AND FAIL THIS PR.');
     }
     await writeMetrics('run_time', test, currentRetry);
   });

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -101,6 +101,11 @@ module.exports = function () {
     if (currentRetry > 0 && (testResult === 'passed' || retries === currentRetry)) {
       await writeMetrics('retry_count', test, currentRetry);
     }
+    if (testResult === undefined) {
+      // If there are any Selenium failures, we cannot let the test fail silently.
+      // We need to force return an exit code 1.
+      throw new Error(`THE TEST RESULT IS UNDEFINED! ABORT ALL TESTS AND FAIL THIS PR.`);
+    }
     await writeMetrics('run_time', test, currentRetry);
   });
 

--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -393,14 +393,19 @@ module.exports = {
           if (checkIfContainerSucceeded === 'Succeeded') {
             console.log(`The container from pod ${podName} is ready! Proceed with the assertion checks..`);
             break;
+          } else if (checkIfContainerSucceeded === 'Failed') {
+            if (params.ignoreFailure === true) {
+              console.log(`The container from pod ${podName} failed as expected! Just ignore as this is part of a negative test.`);
+              break;
+            } else {
+              // The pod failed 4 realz
+              throw new Error(`THE POD FAILED ON ATTEMPT ${i}. OMG!`);
+            }
           }
         }
         if (i === params.nAttempts) {
-          if (params.ignoreFailure === true) {
-            break;
-          } else {
-            throw new Error(`Max number of attempts reached: ${i}`);
-          }
+          // We have reached the max number of attempts. This test has failed
+          throw new Error(`Max number of attempts reached: ${i}`);
         }
       } catch (e) {
         throw new Error(`Failed to obtain a successful phase check from the ${jobName} job on attempt ${i}: ${e.message}`);


### PR DESCRIPTION
We have faced a situation recently where a data file upload test failed due to a missing dependency (`metadata-service` from `ssjdispatcher`). The `checkPod` function kept trying to determine whether or not the `indexing` pod had succeeded but it actually presented a `failed` status, which led the function to, frivolously, continue to check the status of the pod and it led to a situation where the Selenium session got reaped by the Selenium Hub and the test produced a misleading result (It failed silently and returned a ZERO `0` exit code).

This anomaly made 2 PRs turn green misleadingly.

This change improves the polling logic to fail-fast and make an exception bubble up to the Jenkins CDIS Lib groovy caller and force-fail the PR check if any similar issues arise in the future.