### PR TITLE
chore(ci): Adopt python 3.8 in our jenkins-simulate-data.sh script

### DIFF
--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -96,7 +96,7 @@ if [ -f ./pyproject.toml ]; then
   # retry in case of any connectivity failures
   for attempt in {1..3}; do
     yes | poetry cache clear --all pypi
-    pip3 install avro
+    /usr/bin/pip3 install avro
     poetry run pip install --upgrade pip
     poetry install -vv --no-dev
     if [[ $? -ne 0 ]]; then

--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -91,12 +91,11 @@ if [ -f ./pyproject.toml ]; then
   # put poetry in the path
   export PATH="/var/jenkins_home/.local/bin:$PATH"
   poetry config virtualenvs.path "${WORKSPACE}/datasimvirtenv" --local  
-  poetry env use python3.6
+  poetry env use python3.8
   # install data-simulator  
   # retry in case of any connectivity failures
   for attempt in {1..3}; do
     yes | poetry cache clear --all pypi
-    /usr/bin/pip3 install avro
     poetry run pip install --upgrade pip
     poetry install -vv --no-dev
     if [[ $? -ne 0 ]]; then

--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -96,6 +96,7 @@ if [ -f ./pyproject.toml ]; then
   # retry in case of any connectivity failures
   for attempt in {1..3}; do
     yes | poetry cache clear --all pypi
+    pip3 install avro
     poetry run pip install --upgrade pip
     poetry install -vv --no-dev
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Adopt python 3.8 in our jenkins-simulate-data.sh script to unblock the data-simulator's `poetry install` command.