### PR TITLE
chore(load-testing): Select new hardcoded study for sheepdog import script

### DIFF
--- a/load-testing/sheepdog/import-clinical-metadata.js
+++ b/load-testing/sheepdog/import-clinical-metadata.js
@@ -54,7 +54,7 @@ export default function () {
     derived_parent_subject_id: '5c41ec1d49',
     derived_topmed_subject_id: '2fb4aae615',
     '*studies': {
-      submitter_id: 'study_5057ec2ada',
+      submitter_id: 'study_3fbd48dc63',
     },
     '*consent_codes': [],
     project_id: `${program}-${project}`,


### PR DESCRIPTION
Let us avoid the following failure:
```
time="2021-03-01T17:51:05Z" level=info msg="Request response: {\"code\":400,\"created_entity_count\":0,\"entities\":[{\"action\":\"create\",\"errors\":[{\"keys\":[\"studies\"],\"message\":\"No link destination found for studies, unique_keys='[{'project_id': 'DEV-test', 'submitter_id': 'study_5057ec2ada'}]'\",\"type\":\"INVALID_LINK\"}],\"id\":\"a2a68ca9-14b8-47fd-bd72-8fee462685ea\",\"type\":\"subject\",\"unique_keys\":[{\"project_id\":\"DEV-test\",\"submitter_id\":\"90665063-675c-493d-85ea-094895a548c6\"}],\"valid\":false,\"warnings\":[]}],\"entity_error_count\":1,\"message\":\"Transaction aborted due to 1 invalid entity.\",\"success\":false,\"transaction_id\":19809,\"transactional_error_count\":0,\"transactional_errors\":[],\"updated_entity_count\":0}\n" source=console
```