### PR TITLE
chore(test-metadata): Introduce script to list all test suites in label format

### DIFF
--- a/scripts/list-all-test-suites-for-ci.py
+++ b/scripts/list-all-test-suites-for-ci.py
@@ -19,8 +19,6 @@ def collect_test_suites_from_codeceptjs_dryrun():
     elif '.js' in line:
       full_path_to_test_js = line.split('/')
 
-      # TODO: check if there are any @manual annotations in any of the scenarios
-
       suite_folder = full_path_to_test_js[-2]
       # print(f'## suite_folder: {suite_folder}')
       test_script = full_path_to_test_js[-1]

--- a/scripts/list-all-test-suites-for-ci.py
+++ b/scripts/list-all-test-suites-for-ci.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+
+
+def collect_test_suites_from_codeceptjs_dryrun():
+  bashCommand = "npx codeceptjs dry-run 2>&1"
+  process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+  output, error = process.communicate()
+
+  test_suites = []
+
+  for line in output.splitlines():
+    line = line.decode('utf-8')
+    # print(f'### line: {line}')
+
+    # ignore pre-release test suites
+    if 'pre-release' in line:
+      continue
+    elif '.js' in line:
+      full_path_to_test_js = line.split('/')
+
+      # TODO: check if there are any @manual annotations in any of the scenarios
+
+      suite_folder = full_path_to_test_js[-2]
+      # print(f'## suite_folder: {suite_folder}')
+      test_script = full_path_to_test_js[-1]
+      # print(f'## test_script: {test_script}')
+      test_script_without_extension = test_script[0:test_script.index('.')]
+
+      test_suite = f"test-{suite_folder}-{test_script_without_extension}"
+      test_suites.append(test_suite)
+
+  return test_suites
+
+def main():
+  test_suites = collect_test_suites_from_codeceptjs_dryrun()
+  print(f"## ## test_suites: {test_suites}")
+  print(f"## test_suites size: {len(test_suites)}")
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This script will help us feed a list of test suites into the parallelization mechanism (Jenkins Groovy logic).

Here's the current output:
```
gen3-qa [chore/introduce_script_to_list_all_test_suites] % python scripts/list-all-test-suites-for-ci.py
Start setup
HOSTNAME: localhost
## ## test_suites: ['test-access-accessGUITest', 'test-apis-centralizedAuth', 'test-apis-cleverSafeTest', 'test-apis-dataUploadTest', 'test-apis-dbgapTest', 'test-apis-dcfDataReplicationTest', 'test-apis-dcfsMetadataServiceTest', 'test-apis-drsEndpointsTest', 'test-apis-etlTest', 'test-apis-exportToWorkspaceTest', 'test-apis-linkGoogleAccountTest', 'test-apis-metadataIngestionTest', 'test-apis-OAuth2Test', 'test-apis-presignedUrlTest', 'test-apis-rasIntegrationTest', 'test-apis-userTokenTest', 'test-batch-GoogleBucketManifestGenerationTest', 'test-batch-S3BucketManifestGenerationTest', 'test-dream-challenge-DCgen3clientTest', 'test-dream-challenge-synapaseLoginTest', 'test-suites-elasticTest', 'test-suites-fail', 'test-gen3-client-gen3clientTest', 'test-google-checkAllProjectsGoogleBucketAccessTest', 'test-google-googleDataAccessTest', 'test-google-googleServiceAccountKeyTest', 'test-google-googleServiceAccountRemovalTest', 'test-google-googleServiceAccountTest', 'test-guppy-guppyTest', 'test-guppy-nestedAggTest', 'test-guppy-nestedQueryTest', 'test-mariner-marinerIntegrationTest', 'test-pelican-exportPfbTest', 'test-pidgin-getCoremetadataTest', 'test-portal-404pageTest', 'test-portal-coremetadatapageTest', 'test-portal-dashboardReportsTest', 'test-portal-dataExplorerTest', 'test-portal-dataguidOrgTest', 'test-portal-dataUploadTest', 'test-portal-discoveryPageTestPlan', 'test-portal-exportPfbToWorkspaceTest', 'test-portal-exportToWorkspaceTest', 'test-portal-fileExplorerTest', 'test-portal-homepageChartNodesExecutableTestPlan', 'test-portal-homepageTest', 'test-portal-indexingPageTest', 'test-portal-landingPageButtonsTest', 'test-portal-limitedFilePFBExportTestPlan', 'test-portal-loginPageTest', 'test-portal-profilePageTest', 'test-portal-rasAuthN', 'test-portal-roleBasedUITest', 'test-portal-studyViewerTest', 'test-portal-terraExportWarningTestPlan', 'test-portal-tieredAccessTest', 'test-portal-userFormSubmission', 'test-regressions-exportPerformanceTest', 'test-regressions-generateTestData', 'test-regressions-queryPerformanceTest', 'test-regressions-submissionPerformanceTest', 'test-sheepdogAndPeregrine-submitAndQueryNodesTest', 'test-sheepdogAndPeregrine-submitFileTest', 'test-smokeTests-brainTests']
## test_suites size: 64
```