### PR TITLE
chore(debug): Take screenshots on test failures

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -117,6 +117,9 @@ exports.config = {
     tryTo: {
       enabled: true,
     },
+    screenshotOnFail: {
+      enabled: true,
+    },
   },
   timeout: 60000,
   name: 'selenium',


### PR DESCRIPTION
Take screenshots on test failures utilizing a CodeceptJS plugin.

### New Features
- Take screenshots on test failures