### PR TITLE
set keepSessionAlive to false for etl tests

### DIFF
--- a/suites/apis/etlTest.js
+++ b/suites/apis/etlTest.js
@@ -18,7 +18,7 @@ BeforeSuite(async ({ etl }) => {
 Scenario('run ETL first time @etl', async ({ I }) => {
   console.log(`${new Date()}: Before run ETL first time`);
   await bash.runJob('etl', '', false);
-  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 80, ignoreFailure: false, keepSessionAlive: true });
+  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 80, ignoreFailure: false, keepSessionAlive: false });
   console.log(`${new Date()}: After run ETL first time`);
 });
 
@@ -26,7 +26,7 @@ Scenario('run ETL second time @etl', async ({ I, sheepdog }) => {
   console.log(`${new Date()}: Before run ETL second time`);
   await sheepdog.do.runGenTestData(1);
   await bash.runJob('etl', '', false);
-  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 80, ignoreFailure: false, keepSessionAlive: true });
+  await checkPod(I, 'etl', 'gen3job,job-name=etl', { nAttempts: 80, ignoreFailure: false, keepSessionAlive: false });
   console.log(`${new Date()}: After run ETL second time`);
 });
 


### PR DESCRIPTION
Setting keepSessionAlive to false for ETL tests since no session is created in the test flow