### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ If there are things which cannot/should not be fetched in the commons by the set
 ```
 In setup, these values will be read and exported to environment variables before running the test. So in the example above `MY_VAR` is actually going to be a string that will need to be parsed when it's used. Note that the setup gives environment variables higher priority over the config file. So if you did `export MY_VAL="rock"` in the shell you're running the test and in your config had `{ MY_VAL: "scissors" }`, when the test is run, `process.env.MY_VAL === "rock"`.
 
+## Local
+After cloning this repo, get the required packages by running `npm install`.
+
 # Test Development
 ## Running Tests
 Once you have your environment variables configured and the Selenium server is running, you should be able to successfully run the tests.

--- a/README.md
+++ b/README.md
@@ -147,27 +147,6 @@ If there are things which cannot/should not be fetched in the commons by the set
 ```
 In setup, these values will be read and exported to environment variables before running the test. So in the example above `MY_VAR` is actually going to be a string that will need to be parsed when it's used. Note that the setup gives environment variables higher priority over the config file. So if you did `export MY_VAL="rock"` in the shell you're running the test and in your config had `{ MY_VAL: "scissors" }`, when the test is run, `process.env.MY_VAL === "rock"`.
 
-## Local
-After cloning this repo, get the required packages by running `npm install`.
-### Selenium
-To automate web browser actions, CodeceptJS requires a Selenium webserver. You have two options here: Docker or npm. Note that for both methods, you can visit `localhost:4444/status` to see current Selenium session/check that the server is running.
-#### Docker ([link](https://github.com/SeleniumHQ/docker-selenium))
-If you have docker, you can just run the preconfigured container
-```
-docker run -d -p 4444:4444 --name=selenium --rm -v /dev/shm:/dev/shm selenium/standalone-chrome
-```
-To kill the server just kill the container.
-#### npm ([link](https://www.npmjs.com/package/selenium-standalone))
-If you'd rather not fool with docker, you can run the server yourself with an npm package.
-If you already ran `npm install`, the package selenium-standalone should have been installed. You'll also need to install the webdriver, just run `npm run selenium-install`.
-
-You'll need the Java SDK, version 8, to use Selenium so make sure you have that installed as well (check output of `javac -version`, e.g. javac 1.8.0_171 means I have version 8.0_171)
-
-Once this is done, you can run `npm run selenium-start`, and the server will start running on port 4444 by default.
-
-You can kill the server with `npm run selenium-kill`
-
-
 # Test Development
 ## Running Tests
 Once you have your environment variables configured and the Selenium server is running, you should be able to successfully run the tests.


### PR DESCRIPTION
We do not anymore setup the `selenium` and currently it is done via `docker-compose` file

removing the section so that it doesn't throw off engineer with two setup instructions
