### PR TITLE
chore(ras-ci): Skip RAS tests if RAS Staging status is unhealthy (DO NOT MERGE YET)

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -112,6 +112,22 @@ module.exports = function () {
   event.dispatcher.on(event.suite.before, (suite) => {
     console.log('********');
     console.log(`SUITE: ${suite.title}`);
+
+    if (suite.title === 'RASAuthN') {
+      request(`https://authtest.nih.gov/status`, { json: true }, (err, res) => {
+        if (err) { console.log(err); }
+        if (res.statusCode !== 200) {
+          console.log('Skipping RASAuthN tests since RAS Staging is unhealthy...');
+          suite.tests.forEach((test) => {
+            test.run = function skip() { // eslint-disable-line func-names
+              console.log(`Ignoring test - ${test.title}`);
+              this.skip();
+            };
+          });
+        }
+      });
+    }
+
     if (suite.title === 'DrsAPI') {
       request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }


### PR DESCRIPTION
It would be cool to hit the `/status` endpoint before running the test so that we wont have to keep turning RAS tests on and off.