### PR TITLE
donot check portal health when not deployed

### DIFF
--- a/check-pod-health.sh
+++ b/check-pod-health.sh
@@ -16,6 +16,8 @@ fence="${commons_url}/user/jwt/keys"
 selenium="selenium-hub:4444/status"
 if [ -n $1 ] && [ "$1" == "dataguids.org" ]; then
   health_endpoints=( $indexd $portal $selenium )
+elif if ! (g3kubectl get pods --no-headers -l app=portal | grep portal) > /dev/null 2>&1; then
+  health_endpoints=( $sheepdog $peregrine $fence $selenium )
 else
   health_endpoints=( $sheepdog $peregrine $portal $fence $selenium )
 fi

--- a/check-pod-health.sh
+++ b/check-pod-health.sh
@@ -16,7 +16,7 @@ fence="${commons_url}/user/jwt/keys"
 selenium="selenium-hub:4444/status"
 if [ -n $1 ] && [ "$1" == "dataguids.org" ]; then
   health_endpoints=( $indexd $portal $selenium )
-elif if ! (g3kubectl get pods --no-headers -l app=portal | grep portal) > /dev/null 2>&1; then
+elif ! (g3kubectl get pods --no-headers -l app=portal | grep portal) > /dev/null 2>&1; then
   health_endpoints=( $sheepdog $peregrine $fence $selenium )
 else
   health_endpoints=( $sheepdog $peregrine $portal $fence $selenium )


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements
There is now a commons without portal. So, added logic to prevent portal health check when the service is not deployed

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
