### PR TITLE
fix(guppy-ci): Mutate guppy config to point to Canine indices before running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@chore/skip_k8sReset') _
 
 testPipeline {
   // tell the pipeline to not checkout `gen3-qa:master`

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -9,7 +9,7 @@ let token;
 Before(async ({ users, fence }) => {
   // Mutate guppy config to point guppy to pre-defined Canine ETL'ed data
   // more details: https://github.com/uc-cdis/cloud-automation/pull/1667
-  await bash.runCommand(`export KUBECTL_NAMESPACE="${process.env.NAMESPACE}" && gen3 mutate-guppy-config-for-guppy-test`);
+  await bash.runCommand(`export KUBECTL_NAMESPACE="${process.env.KUBECTL_NAMESPACE}" && gen3 mutate-guppy-config-for-guppy-test`);
 
   const scope = ['data', 'user'];
   const apiKeyRes = await fence.complete.createAPIKey(scope, users.mainAcct.accessTokenHeader);

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -1,8 +1,15 @@
 Feature('Guppy');
 
+const { Bash } = require('../../utils/bash.js');
+const bash = new Bash();
+
 let token;
 
 Before(async ({ users, fence }) => {
+  // Mutate guppy config to point guppy to pre-defined Canine ETL'ed data
+  // more details: https://github.com/uc-cdis/cloud-automation/pull/1667
+  await bash.runCommand(`export KUBECTL_NAMESPACE="${process.env.NAMESPACE}" && gen3 mutate-guppy-config-for-guppy-test`);
+
   const scope = ['data', 'user'];
   const apiKeyRes = await fence.complete.createAPIKey(scope, users.mainAcct.accessTokenHeader);
   token = await fence.do.getAccessToken(apiKeyRes.data.api_key);

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -1,6 +1,7 @@
 Feature('Guppy');
 
 const { Bash } = require('../../utils/bash.js');
+
 const bash = new Bash();
 
 let token;

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -1,15 +1,41 @@
 Feature('Guppy');
 
+const { sleepMS } = require('../../utils/apiUtil.js');
 const { Bash } = require('../../utils/bash.js');
 
 const bash = new Bash();
 
 let token;
 
-Before(async ({ users, fence }) => {
+Before(async ({ I, users, fence }) => {
   // Mutate guppy config to point guppy to pre-defined Canine ETL'ed data
   // more details: https://github.com/uc-cdis/cloud-automation/pull/1667
-  await bash.runCommand(`export KUBECTL_NAMESPACE="${process.env.KUBECTL_NAMESPACE}" && gen3 mutate-guppy-config-for-guppy-test`);
+  await bash.runCommand('gen3 mutate-guppy-config-for-guppy-test');
+
+  await sleepMS(30000);
+  // start polling logic to capture new es indices
+  const nAttempts = 24; // 2 minutes and then we give up :(
+  let guppyStatusCheckResp = '';
+  for (let i = 0; i < nAttempts; i += 1) {
+    console.log(`waiting for the new guppy pod with the expected predefined canine indices - Attempt #${i}...`);
+    guppyStatusCheckResp = await I.sendGetRequest(
+      `https://${process.env.NAMESPACE}.planx-pla.net/guppy/_status`,
+      users.mainAcct.accessTokenHeader,
+    );
+    if (guppyStatusCheckResp.status === 200
+      && (Object.prototype.hasOwnProperty.call(guppyStatusCheckResp.data.indices, 'jenkins_subject_1')
+      && Object.prototype.hasOwnProperty.call(guppyStatusCheckResp.data.indices, 'jenkins_file_1'))) {
+      console.log(`${new Date()}: all good, proceed with the test...`);
+      break;
+    } else {
+      console.log(`${new Date()}: The expected predefined canine indices did not show up on guppy's status payload yet...`);
+      await sleepMS(5000);
+      if (i === nAttempts - 1) {
+        console.log(`${new Date()}: The new guppy pod never came up with the expected indices: Details: ${guppyStatusCheckResp.data}`);
+        console.log(`err: ${guppyStatusCheckResp.data}`);
+      }
+    }
+  }
 
   const scope = ['data', 'user'];
   const apiKeyRes = await fence.complete.createAPIKey(scope, users.mainAcct.accessTokenHeader);


### PR DESCRIPTION
We need to be able to mutate the guppy config in our CI environments for 2 test flows:

- DYNAMIC data to test the end-to-end flow of the Export to PFB and Export to Workspace features.
- PREDEFINED data to test Guppy queries based on Queries and Expected Responses (based on Canine DD -- ES index pre-hydrated).

This change takes care of the PREDEFINED test flow.