### PR TITLE
getServiceVersion: handle service names with dash

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ getServiceVersion() {
   local command
   local response
   local version
-  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r '.[\"$1\"]'"
+  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r "'".[\"$s\"]"'""
   response=$(eval "$command")
 
   # Get last item of delimited string using string operators:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ getServiceVersion() {
   local command
   local response
   local version
-  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r "'".[\"$s\"]"'""
+  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r "'".[\"$1\"]"'""
   response=$(eval "$command")
 
   # Get last item of delimited string using string operators:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ getServiceVersion() {
   local command
   local response
   local version
-  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r .$1"
+  command="g3kubectl get configmap manifest-versions -o json | jq -r .data.json | jq -r '.[\"$1\"]'"
   response=$(eval "$command")
 
   # Get last item of delimited string using string operators:


### PR DESCRIPTION
closes #651

### Bug Fixes
- Handle service names with dash in `getServiceVersion`/`runTestsIfServiceVersion`
