### PR TITLE
chore(ci): Improve stability of the Guppy test

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -438,6 +438,8 @@ else
   echo "INFO: disabling audit-service tests"
   donot '@audit'
 fi
+# the tests assume audit-service can read from an AWS SQS
+runTestsIfServiceVersion "@audit" "audit-service" "1.0.0" "2021.06"
 
 ########################################################################################
 

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -31,8 +31,10 @@ Before(async ({ I, users, fence }) => {
       console.log(`${new Date()}: The expected predefined canine indices did not show up on guppy's status payload yet...`);
       await sleepMS(5000);
       if (i === nAttempts - 1) {
-        console.log(`${new Date()}: The new guppy pod never came up with the expected indices: Details: ${guppyStatusCheckResp.data}`);
+        const errMsg = `${new Date()}: The new guppy pod never came up with the expected indices: Details: ${guppyStatusCheckResp.data}`;
+        console.log(errMsg);
         console.log(`err: ${guppyStatusCheckResp.data}`);
+        throw new Error(`ERROR: ${errMsg}`);
       }
     }
   }

--- a/suites/guppy/guppyTest.js
+++ b/suites/guppy/guppyTest.js
@@ -36,6 +36,8 @@ Before(async ({ I, users, fence }) => {
       }
     }
   }
+  // wait a bit for any old pod replicas to go away
+  await sleepMS(30000);
 
   const scope = ['data', 'user'];
   const apiKeyRes = await fence.complete.createAPIKey(scope, users.mainAcct.accessTokenHeader);


### PR DESCRIPTION
Facing intermittent errors:
```
Guppy: I want a list of patients (subjects) strictly younger than 30 with a past stroke in ascending order of BMI. @guppyAPI – I want a list of patients (subjects) strictly younger than 30 with a past stroke in ascending order of BMI. @guppyAPI
<1s
Error
expected 400 to equal 200
```