### PR TITLE
fix bucketname logic

### DIFF
--- a/suites/portal/dataUploadTest.js
+++ b/suites/portal/dataUploadTest.js
@@ -46,7 +46,7 @@ const uploadFile = async function (I, dataUpload, indexd, sheepdog, nodes, fileO
     const maxAttempts = 6;
     // const jenkinsNamespace = process.env.HOSTNAME.replace('.planx-pla.net', '');
     // const bucketName = `${jenkinsNamespace}-databucket-gen3`;
-    const bucketName = bash.runCommand('cat ~/Gen3Secrets/apis_configs/fence-config.yaml | yq -r .DATA_UPLOAD_BUCKET');
+    const bucketName = bash.runCommand('gen3 secrets decode fence-config fence-config.yaml | yq -r .DATA_UPLOAD_BUCKET');
     console.log(bucketName);
     for (let i = 1; i <= maxAttempts; i += 1) {
       try {

--- a/suites/portal/dataUploadTest.js
+++ b/suites/portal/dataUploadTest.js
@@ -44,9 +44,10 @@ const uploadFile = async function (I, dataUpload, indexd, sheepdog, nodes, fileO
   // additional scrutiny for file upload only when running inside Jenkins
   if (inJenkins) {
     const maxAttempts = 6;
-    const jenkinsNamespace = process.env.HOSTNAME.replace('.planx-pla.net', '');
-    const bucketName = `${jenkinsNamespace}-databucket-gen3`;
-
+    // const jenkinsNamespace = process.env.HOSTNAME.replace('.planx-pla.net', '');
+    // const bucketName = `${jenkinsNamespace}-databucket-gen3`;
+    const bucketName = bash.runCommand('cat ~/Gen3Secrets/apis_configs/fence-config.yaml | yq -r .DATA_UPLOAD_BUCKET');
+    console.log(bucketName);
     for (let i = 1; i <= maxAttempts; i += 1) {
       try {
         console.log(`waiting for file [${fileName}] with guid [${fileGuid}] to show up on ${bucketName}... - attempt ${i}`);


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
We are not fetching the bucket name from config but relying on the standard naming convention. This fixes that.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
