### PR TITLE
fix(pfb-export): Fix polling logic to indentify PR indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TL;DR
 
-gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfile` pipeline in each github repo
+gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfile` pipeline in each github repo.
 
 ## Basic test run
 

--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -230,9 +230,7 @@ Scenario('Mutate manifest-guppy config and roll guppy so the recently-submitted 
     );
 
     if (guppyStatusCheckResp.status === 200
-      && (Object.prototype.hasOwnProperty.call(guppyStatusCheckResp.data.indices, `${I.cache.prNumber}.${I.cache.repoName}.${process.env.NAMESPACE}_etl`)
-      || Object.prototype.hasOwnProperty.call(guppyStatusCheckResp.data.indices, `${I.cache.prNumber}.${I.cache.repoName}.${process.env.NAMESPACE}_subject`)
-      || Object.prototype.hasOwnProperty.call(guppyStatusCheckResp.data.indices, `${I.cache.prNumber}.${I.cache.repoName}.${process.env.NAMESPACE}_file`))) {
+      && Object.keys(guppyStatusCheckResp.data.indices).filter((k) => k.includes(`${I.cache.prNumber}.${I.cache.repoName}`)).length > 0) {
       console.log(`${new Date()}: all good, proceed with the assertions...`);
       break;
     } else {


### PR DESCRIPTION
The name of the index is not `1520.gitops-qa.jenkins-new_etl` it is actually `1520.gitops-qa.qa-dcp_etl` so this polling logic is wrong because NAMESPACE is `jenkins-new`.