### PR TITLE
Do not run audit-service tests if fence version is too old

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -450,6 +450,7 @@ else
 fi
 # the tests assume audit-service can read from an AWS SQS
 runTestsIfServiceVersion "@audit" "audit-service" "1.0.0" "2021.06"
+runTestsIfServiceVersion "@audit" "fence" "5.1.0" "2021.07"
 
 ########################################################################################
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -450,6 +450,7 @@ else
 fi
 # the tests assume audit-service can read from an AWS SQS
 runTestsIfServiceVersion "@audit" "audit-service" "1.0.0" "2021.06"
+# the tests assume fence records both successful and unsuccessful events
 runTestsIfServiceVersion "@audit" "fence" "5.1.0" "2021.07"
 
 ########################################################################################


### PR DESCRIPTION
### Bug Fixes
- Do not run audit-service tests if fence version is too old
