### PR TITLE
fix(pfb-export): Refactor logic to use proper targetMappingNode

### DIFF
--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -42,7 +42,7 @@ BeforeSuite(async ({ I }) => {
   I.cache.prNumber = prNumber;
 
   // handling the targetMappingNode
-  // submitted_unaligned_reads is set by default in pretty every dictionary
+  // submitted_unaligned_reads is set by default in pretty much every dictionary
   // cloud-automation/blob/master/kube/services/jobs/gentestdata-job.yaml
   // if this is running against an Anvil DD, sequencing must be used
   // TODO: Look into reusing the leafNode logic from jenkins-simulate-data.sh

--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -298,6 +298,11 @@ Scenario('Visit the Explorer page, select a cohort, export to PFB and download t
     // checks if the Filters are present on the left side of Exploration Page
     I.seeElement('//h4[contains(text(),\'Filters\')]', 5);
 
+    // If bloodpac-like environment, switch to the "Cases" tab
+    if (process.env.testedEnv.includes('blood')) {
+      I.click('//h3[contains(text(),\'Cases\')]');
+    }
+
     // TODO: Select random cohorts to try different PFBs
 
     // checks if the `Export to PFB` button is disabled on the page
@@ -331,7 +336,7 @@ Scenario('Visit the Explorer page, select a cohort, export to PFB and download t
   I.click('//button[contains(text(),\'Export to PFB\')]');
 
   // Check if the footer shows expected msg
-  I.seeElement({ xpath: '//div[@class=\'explorer-button-group__toaster-text\']/div[contains(.,\'Please do not navigate away from this page until your export is finished.\')]' }, 10);
+  I.seeElement({ xpath: '//div[@class=\'explorer-button-group__toaster-text\']/div[contains(.,\'Please do not navigate away from this page until your export is finished.\')]' }, 60);
 
   // check if the pelican-export pod (sower job) runs successfully
   await checkPod(I, 'pelican-export', 'sowerjob', { nAttempts: 80, ignoreFailure: false, keepSessionAlive: false });


### PR DESCRIPTION
Handling the targetMappingNode
 The `submitted_unaligned_reads` node is set by default in pretty much every dictionary (as per the default args in this script: `cloud-automation/blob/master/kube/services/jobs/gentestdata-job.yaml`).
However, if this user flow is running against the Anvil Data Dictionary, the `sequencing` node must be used.

TODO: Look into reusing the leafNode logic from jenkins-simulate-data.sh