### PR TITLE
fix(run-test.sh): Improve the studyViewer code

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -393,7 +393,7 @@ fi
 # Study Viewer test
 runStudyViewerTests=true
 if ! [[ "$service" =~ ^(data-portal|requestor|gen3-qa)$ ]]; then
-  if [[ "$service" =~ ^(cdis-manifest|gitops-qa)]]; then
+  if [[ "$service" =~ ^(cdis-manifest|gitops-qa)$ ]]; then
     if ! (g3kubectl get pods --no-headers -l app=requestor | grep requestor) > /dev/null 2>&1; then
       echo "### Study-Viewer is not deployed"
       runStudyViewerTests=false

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -403,7 +403,7 @@ if ! [[ "$service" =~ ^(data-portal|requestor|gen3-qa)$ ]]; then
     runStudyViewerTests=false
   fi
 fi
-if [[runStudyViewerTests = true]; then
+if [[runStudyViewerTests = true]]; then
   echo "Enabling study-viewer test"
 else
   echo "Disabling study-viewer test"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -408,6 +408,7 @@ if [[runStudyViewerTests = true]; then
 else
   echo "Disabling study-viewer test"
   donot "@studyViewer"
+fi
 
 # landing page buttons
 if [[ $(curl -s "$portalConfigURL" | jq '.components | contains({buttons}) | not') == "true" ]] || [[ ! -z "$testedEnv" ]]; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -390,13 +390,24 @@ if [ -z "$checkForPresenceOfMetadataIngestionSowerJob" ]; then
   donot '@metadataIngestion'
 fi
 
-# studyViewer
-if [[ $(curl -s "$portalConfigURL" | jq 'contains({studyViewerConfig}) | not') == "true" ]]; then
-  donot '@studyViewer'
-elif ! (g3kubectl get pods --no-headers -l app=requestor | grep requestor) > /dev/null 2>&1; then
-  donot '@studyViewer'
+# Study Viewer test
+runStudyViewerTests=true
+if ! [[ "$service" =~ ^(data-portal|requestor|gen3-qa)$ ]]; then
+  if [[ "$service" =~ ^(cdis-manifest|gitops-qa)]]; then
+    if ! (g3kubectl get pods --no-headers -l app=requestor | grep requestor) > /dev/null 2>&1; then
+      echo "### Study-Viewer is not deployed"
+      runStudyViewerTests=false
+    fi
+  else
+    echo "### Not necessary run Study-Viewer test for repo $service"
+    runStudyViewerTests=false
+  fi
 fi
-#donot '@studyViewer'
+if [[runStudyViewerTests = true]; then
+  echo "Enabling study-viewer test"
+else
+  echo "Disabling study-viewer test"
+  donot "@studyViewer"
 
 # landing page buttons
 if [[ $(curl -s "$portalConfigURL" | jq '.components | contains({buttons}) | not') == "true" ]] || [[ ! -z "$testedEnv" ]]; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -403,7 +403,7 @@ if ! [[ "$service" =~ ^(data-portal|requestor|gen3-qa)$ ]]; then
     runStudyViewerTests=false
   fi
 fi
-if [[runStudyViewerTests = true]]; then
+if [[ "$runStudyViewerTests" == true ]]; then
   echo "Enabling study-viewer test"
 else
   echo "Disabling study-viewer test"

--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -59,7 +59,15 @@ AfterSuite(async () => {
 
 Scenario('Submit dummy data to the Gen3 Commons environment @pfbExport', async ({ I, users }) => {
   // generate dummy data
-  bash.runJob('gentestdata', 'SUBMISSION_USER cdis.autotest@gmail.com MAX_EXAMPLES 1');
+  let genTestDataArgs = 'SUBMISSION_USER cdis.autotest@gmail.com MAX_EXAMPLES 1';
+  if (process.env.testedEnv.includes('anvil')) {
+    // submitted_unaligned_reads is set by default in:
+    // cloud-automation/blob/master/kube/services/jobs/gentestdata-job.yaml
+    // if this is running against an Anvil DD, sequencing must be used
+    genTestDataArgs += ' SUBMISSION_ORDER sequencing';
+  }
+
+  bash.runJob('gentestdata', genTestDataArgs);
   await checkPod(I, 'gentestdata', 'gen3job,job-name=gentestdata');
 
   // Graph node for file mapping


### PR DESCRIPTION
Improve the repo checks around the way studyViewer tests are executed.

The studyViewer test should only run in `data-portal, requestor and gen3-qa` service repos and it should run against NCT `gitops-qa` and `cdis-manifest` PR