### PR TITLE
fix(pfx-export-test): Tweak assertions based on specific Data Dictionaries

### DIFF
--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -404,7 +404,10 @@ Scenario('Install the latest pypfb CLI version and make sure we can parse the av
   const itDDNodesSet = ddNodesSet.values();
   expect(itDDNodesSet.next().value).to.equal('program');
   expect(itDDNodesSet.next().value).to.equal('project');
-  expect(itDDNodesSet.next().value).to.equal('study');
-
+  if (I.cache.testedEnv.includes('anvil')) {
+    expect(itDDNodesSet.next().value).to.equal('subject');
+  } else {
+    expect(itDDNodesSet.next().value).to.equal('study');
+  }
   // TODO: Refine cohort later and make sure the selected projects show up in the PFB file
 });

--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -263,8 +263,10 @@ Scenario('Mutate manifest-guppy config and roll guppy so the recently-submitted 
       console.log(`${new Date()}: The new indices did not show up on guppy's status payload yet...`);
       await sleepMS(5000);
       if (i === nAttempts - 1) {
-        console.log(`${new Date()}: The new guppy pod never came up with the new indices: Details: ${guppyStatusCheckResp.data}`);
-        console.log(`err: ${guppyStatusCheckResp.data}`);
+        console.log(`${new Date()}: The new guppy pod never came up with the new indices.`);
+        // TODO: Capture logs from guppy pod that failed to come up
+        // fail fast (there is no point in running the remaining scenarios)
+        throw new Error('The new guppy pod never came up with the new indices');
       }
     }
   }


### PR DESCRIPTION
Fixing assertion that was set on the wrong assumption the Clinical Data Model hierarchy traversal path  (program -> project -> study) would always be the same.

This test failed recently while running against an environment mutated with `gen3.theanvil.io` artifacts.
```
 PFB Export: Install the latest pypfb CLI version and make sure we can parse the avro file @pfbExport – Install the latest pypfb CLI version and make sure we can parse the avro file @pfbExport
1m 44s
Error
expected 'subject' to equal 'study'
Stacktrace
AssertionError: expected 'subject' to equal 'study'
```

ANVIL has program -> project -> subject
BDCAT has program -> project -> study (as originally expected)

There is a need for a better logic to assemble the right assertion around the PFB structure.