### PR TITLE
fix(ga4gh): use specified GA4GH endpoint, not indexd-specific exposur…

### DIFF
--- a/docs/testplans/environment-specific/dataguidsorg-test-plan.md
+++ b/docs/testplans/environment-specific/dataguidsorg-test-plan.md
@@ -26,6 +26,6 @@
     To do that, manually or automatically get GUID from each host which is listed in [DIST config](https://github.com/uc-cdis/cdis-manifest/blob/master/dataguids.org/manifest.json#L33). (Note: this might not test the prefixes since the first GUID you find will not necessarily contain a prefix. it will only test the resolution.)
 
 2. Test GUID without prefixes
-3. Test DRS endpoints - check DRS endpoints by given any random GUID such as https://dataguids.org//ga4gh/drs/v1/objects/dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe
+3. Test DRS endpoints - check DRS endpoints by given any random GUID such as https://dataguids.org/ga4gh/drs/v1/objects/dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe
 4. Test bundles - Test GUID which has bundle form (Note: none of the production commons use bundles right now. If we want to check it, we could go to /bundle for each Commons, and if there are existing bundles, try to resolve a random one with http://dataguids.org/ )
 5. Negative test - When user input invalid GUID, the expected output is “Data GUID &lt;user input> not found.”

--- a/docs/testplans/environment-specific/dataguidsorg-test-plan.md
+++ b/docs/testplans/environment-specific/dataguidsorg-test-plan.md
@@ -26,6 +26,6 @@
     To do that, manually or automatically get GUID from each host which is listed in [DIST config](https://github.com/uc-cdis/cdis-manifest/blob/master/dataguids.org/manifest.json#L33). (Note: this might not test the prefixes since the first GUID you find will not necessarily contain a prefix. it will only test the resolution.)
 
 2. Test GUID without prefixes
-3. Test DRS endpoints - check DRS endpoints by given any random GUID such as https://dataguids.org/index/ga4gh/drs/v1/objects/dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe
+3. Test DRS endpoints - check DRS endpoints by given any random GUID such as https://dataguids.org//ga4gh/drs/v1/objects/dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe
 4. Test bundles - Test GUID which has bundle form (Note: none of the production commons use bundles right now. If we want to check it, we could go to /bundle for each Commons, and if there are existing bundles, try to resolve a random one with http://dataguids.org/ )
 5. Negative test - When user input invalid GUID, the expected output is “Data GUID &lt;user input> not found.”

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -113,7 +113,7 @@ module.exports = function () {
     console.log('********');
     console.log(`SUITE: ${suite.title}`);
     if (suite.title === 'DrsAPI') {
-      request(`https://${process.env.HOSTNAME}/index/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
+      request(`https://${process.env.HOSTNAME}//ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');

--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -113,7 +113,7 @@ module.exports = function () {
     console.log('********');
     console.log(`SUITE: ${suite.title}`);
     if (suite.title === 'DrsAPI') {
-      request(`https://${process.env.HOSTNAME}//ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
+      request(`https://${process.env.HOSTNAME}/ga4gh/drs/v1/objects`, { json: true }, (err, res) => {
         if (err) { console.log(err); }
         if (res.statusCode !== 200) {
           console.log('Skipping DRS tests since its endpoints are not enabled on this environment...');

--- a/load-testing/indexd/drs-endpoint.js
+++ b/load-testing/indexd/drs-endpoint.js
@@ -27,7 +27,7 @@ export const options = {
 };
 
 export default function () {
-  const url = `https://${GEN3_HOST}/index/ga4gh/drs/v1/objects/${guids[Math.floor(Math.random() * guids.length)]}/access/${SIGNED_URL_PROTOCOL}`;
+  const url = `https://${GEN3_HOST}//ga4gh/drs/v1/objects/${guids[Math.floor(Math.random() * guids.length)]}/access/${SIGNED_URL_PROTOCOL}`;
   const params = {
     headers: {
       'Content-Type': 'application/json',

--- a/load-testing/indexd/drs-endpoint.js
+++ b/load-testing/indexd/drs-endpoint.js
@@ -27,7 +27,7 @@ export const options = {
 };
 
 export default function () {
-  const url = `https://${GEN3_HOST}//ga4gh/drs/v1/objects/${guids[Math.floor(Math.random() * guids.length)]}/access/${SIGNED_URL_PROTOCOL}`;
+  const url = `https://${GEN3_HOST}/ga4gh/drs/v1/objects/${guids[Math.floor(Math.random() * guids.length)]}/access/${SIGNED_URL_PROTOCOL}`;
   const params = {
     headers: {
       'Content-Type': 'application/json',

--- a/services/apis/drs/drsProps.js
+++ b/services/apis/drs/drsProps.js
@@ -2,7 +2,7 @@ const { Gen3Response } = require('../../../utils/apiUtil');
 /**
  * DRS Properties
  */
-const apiRoot = '//ga4gh/drs/v1/objects';
+const apiRoot = '/ga4gh/drs/v1/objects';
 module.exports = {
   /**
    * DRS endpoints

--- a/services/apis/drs/drsProps.js
+++ b/services/apis/drs/drsProps.js
@@ -2,7 +2,7 @@ const { Gen3Response } = require('../../../utils/apiUtil');
 /**
  * DRS Properties
  */
-const apiRoot = '/index/ga4gh/drs/v1/objects';
+const apiRoot = '//ga4gh/drs/v1/objects';
 module.exports = {
   /**
    * DRS endpoints


### PR DESCRIPTION
…e of it


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Use the root/ga4gh/drs/v1/... endpoint (the standard API specified by the GA4GH spec) rather than indexd's exposure via root/index/ga4gh

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
