### PR TITLE
chore(ci): Do not interrupt CI if influxdb is down

### DIFF
--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -21,8 +21,10 @@ function writeMetricWithResult() {
     measure="fail_count"
   fi
 
+  set +e
   # allow failure in case influxdb not in use
   curl -i -XPOST "http://influxdb:8086/write?db=ci_metrics" --data-binary "${measure},test_name=data_simulator,repo_name=$(echo $JOB_NAME | cut -d/ -f 2),pr_num=$(echo $BRANCH_NAME | cut -d- -f 2) ${measure}=1" || true
+  set -e
 }
 
 namespace="${1:-${KUBECTL_NAMESPACE:-default}}"


### PR DESCRIPTION
Avoid this interruption:
```
curl: (7) Failed to connect to influxdb port 8086: Connection timed out
+ exit 0

ERROR: script returned exit code 7

StackTrace:
hudson.AbortException: script returned exit code 7
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.handleExit(DurableTaskStep.java:659)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.check(DurableTaskStep.java:605)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.run(DurableTaskStep.java:549)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

script returned exit code 7+ kubectl get cm --namespace jenkins-blood global -o jsonpath=****.data.environment}
GEN3_HOME is ...Hub_Org_cloud-automation_PR-1740/cloud-automation
BRANCH_NAME is PR-1740
CHANGE_BRANCH is fix/hatchery
```