### PR TITLE
fix: disco search bar locator

### DIFF
--- a/services/portal/discovery/discoveryProps.js
+++ b/services/portal/discovery/discoveryProps.js
@@ -7,7 +7,7 @@ module.exports = {
     css: '.ant-pagination-next[title="Next Page"]',
   },
   txtDiscoverySearch: {
-    xpath: '//div[@class="discovery-search-container"]/span/input[@type="text"]',
+    xpath: '//div[contains(@class,"discovery-search-container")]/span/input[@type="text"]',
   },
   btnAdvancedSearch: {
     xpath: '//button[span[text()="ADVANCED SEARCH"]]',


### PR DESCRIPTION
`txtDiscoverySearch` now works for both old and new tag/search components in Discovery page

Related PR: https://github.com/uc-cdis/data-portal/pull/927

### Improvements
- `txtDiscoverySearch` now works for both old and new tag/search components in Discovery page