### PR TITLE
fix(python): use broadly supposed version of python to setup test env…

### DIFF
--- a/jenkins-simulate-data.sh
+++ b/jenkins-simulate-data.sh
@@ -94,7 +94,7 @@ if [ -f ./pyproject.toml ]; then
   # put poetry in the path
   export PATH="/var/jenkins_home/.local/bin:$PATH"
   poetry config virtualenvs.path "${WORKSPACE}/datasimvirtenv" --local
-  poetry env use python3.8
+  poetry env use python3.6
   # install data-simulator
   # retry in case of any connectivity failures
   for attempt in {1..3}; do


### PR DESCRIPTION
… (this was failing with the SDK installation)


### New Features


### Breaking Changes


### Bug Fixes
- use broadly supposed version of python to setup test env (this was failing with the SDK installation)

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
