### PR TITLE
add support for running tests locally on arm64 processor based machines

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -106,7 +106,7 @@
         "filename": "README.md",
         "hashed_secret": "398ec9c29cf195ff9202bd85b75002adc88832c3",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 147
       }
     ],
     "getAccessToken.sh": [
@@ -407,5 +407,5 @@
       }
     ]
   },
-  "generated_at": "2021-09-13T20:34:20Z"
+  "generated_at": "2021-12-10T14:48:26Z"
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfil
 
 ### Start test infra (influxdb, grafana, selenium)
 
+For using linux/amd64 selenium images:
 ```
 # start test infra
 docker-compose -f docker-compose-test-infra.yaml up -d
+```
+
+For using arm64 selenium images:
+```
+docker-compose -f docker-compose-test-infra-arm64.yaml up -d
 ```
 
 ### Initial setup of influxdb and grafana (only needed on a new containers)

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ gen3 integration tests - run by https://jenkins.planx-pla.net/ via a `Jenkinsfil
 For using linux/amd64 selenium images:
 ```
 # start test infra
-docker-compose -f docker-compose-test-infra.yaml up -d
+docker compose -f docker-compose-test-infra.yaml up -d
 ```
 
 For using arm64 selenium images:
 ```
-docker-compose -f docker-compose-test-infra-arm64.yaml up -d
+docker compose -f docker-compose-test-infra-arm64.yaml up -d
 ```
 
 ### Initial setup of influxdb and grafana (only needed on a new containers)

--- a/docker-compose-test-infra-arm64.yaml
+++ b/docker-compose-test-infra-arm64.yaml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+  influxdb:
+    image: influxdb:1.8.4
+    ports:
+      - '8086:8086'
+    volumes:
+      - influxdb-storage:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=ci_metrics
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - '3000:3000'
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./grafana-provisioning/:/etc/grafana/provisioning
+    depends_on:
+      - influxdb
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+  hub:
+    image: seleniarm/hub:4.0.0-20211111
+    container_name: selenium-hub
+    ports:
+      - '4444:4444'
+      - '4442:4442'
+      - '4443:4443'
+  chrome:
+    image: seleniarm/node-chromium:4.0.0-20211111
+    container_name: node-chrome
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - hub
+    environment:
+      SE_EVENT_BUS_HOST: hub
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+volumes:
+  influxdb-storage:
+  grafana-storage:


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Ability to run tests locally Apple M1 machines. The selenium images built for linux/amd64 do not run well on Mac M1's Docker Desktop (emulation mode does not work well, connections to selenium hub are too slow and fail a lot).

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
