### PR TITLE
Updating the DD host for test_results

### DIFF
--- a/hooks/test_results.js
+++ b/hooks/test_results.js
@@ -18,7 +18,7 @@ let ddClient;
 if (process.env.JENKINS_HOME && process.env.RUNNING_LOCAL !== 'true') {
   console.log('### ## Initializing DataDog Client...');
   ddClient = new StatsD({
-    host: 'datadog-agent-cluster-agent.datadog',
+    host: 'datadog-cluster-agent.datadog',
     port: 8125,
     globalTags: { env: testEnvironment },
     errorHandler(error) {


### PR DESCRIPTION
Updating the DD host from `datadog-agent-cluster-agent.datadog` to `datadog-cluster-agent.datadog` as the datadog deployment was moved to HELM