### PR TITLE
Dont run tests when required service is not deployed

### DIFF
--- a/suites/apis/requestorTest.js
+++ b/suites/apis/requestorTest.js
@@ -1,4 +1,4 @@
-Feature('RequestorAPI requires-requestor');
+Feature('RequestorAPI @requires-requestor');
 
 /**
   This set of integration tests test the flow of requestor service

--- a/suites/apis/requestorTest.js
+++ b/suites/apis/requestorTest.js
@@ -1,4 +1,4 @@
-Feature('RequestorAPI');
+Feature('RequestorAPI requires-requestor');
 
 /**
   This set of integration tests test the flow of requestor service

--- a/suites/portal/coremetadatapageTest.js
+++ b/suites/portal/coremetadatapageTest.js
@@ -1,4 +1,4 @@
-Feature('CoreMetadataPageTest @requires-indexd @requires-portal');
+Feature('CoreMetadataPageTest @requires-indexd @requires-portal @requires-pidgin');
 
 const I = actor();
 


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Don't run corematadatapage tests when pidgin is not deployed
Don't run requestor tests when requestor is not deployed

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
