### PR TITLE
fix: require sower instead of indexd

### DIFF
--- a/suites/portal/discoveryPageTest.js
+++ b/suites/portal/discoveryPageTest.js
@@ -6,7 +6,7 @@ const { output } = require('codeceptjs');
 const I = actor();
 I.cache = {};
 
-Feature('Discovery page @discoveryPage @requires-portal @requires-metadata @requires-sower @aggMDS');
+Feature('Discovery page @discoveryPage @requires-portal @requires-metadata @requires-indexd @requires-sower @aggMDS');
 
 After(({ users, mds }) => {
   if ('studyId' in I.cache) {

--- a/suites/portal/discoveryPageTest.js
+++ b/suites/portal/discoveryPageTest.js
@@ -6,7 +6,7 @@ const { output } = require('codeceptjs');
 const I = actor();
 I.cache = {};
 
-Feature('Discovery page @discoveryPage @requires-portal @requires-metadata @requires-indexd');
+Feature('Discovery page @discoveryPage @requires-portal @requires-metadata @requires-sower');
 
 After(({ users, mds }) => {
   if ('studyId' in I.cache) {


### PR DESCRIPTION

### Bug Fixes
- Require `sower` instead of `indexd` for discovery page tests

