### PR TITLE
Fix 'checkPod' logic

### DIFF
--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -405,12 +405,13 @@ module.exports = {
         }
 
         // get all pods that match the provided label
-        const podsNames = await bash.runCommand(`g3kubectl get pod --sort-by=.metadata.creationTimestamp -l app=${labelName} -o jsonpath="{.items[*].metadata.name}"`);
+        let podsNames = await bash.runCommand(`g3kubectl get pod --sort-by=.metadata.creationTimestamp -l app=${labelName} -o jsonpath="{.items[*].metadata.name}"`);
         console.log(`Found pods with label '${labelName}': ${podsNames}`);
 
         // if there's more than 1 pod matching the provided name, the last one
         // is the most recent (`--sort-by=.metadata.creationTimestamp`)
-        const podName = podsNames.split(' ').filter((name) => name.startsWith(jobName)).at(-1);
+        podsNames = podsNames.split(' ').filter((name) => name.startsWith(jobName));
+        const podName = podsNames[podsNames.length - 1];
         console.log(`Found latest pod with name '${jobName}': '${podName}'`);
 
         if (!podFound) {

--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -410,7 +410,7 @@ module.exports = {
 
         // if there's more than 1 pod matching the provided name, the last one
         // is the most recent (`--sort-by=.metadata.creationTimestamp`)
-        const podName = podsNames.split(" ").filter(name => name.startsWith(jobName)).at(-1);
+        const podName = podsNames.split(' ').filter((name) => name.startsWith(jobName)).at(-1);
         console.log(`Found latest pod with name '${jobName}': '${podName}'`);
 
         if (!podFound) {

--- a/utils/apiUtil.js
+++ b/utils/apiUtil.js
@@ -398,14 +398,14 @@ module.exports = {
         if (process.env.RUNNING_LOCAL === 'true') {
           process.env.KUBECTL_NAMESPACE = process.env.NAMESPACE;
         }
-        console.log(`### THE KUBECTL_NAMESPACE: ${process.env.KUBECTL_NAMESPACE}`);
-        const podNameDebug = await bash.runCommand('echo "$KUBECTL_NAMESPACE"');
         if (process.env.DEBUG === 'true') {
+          console.log(`### THE KUBECTL_NAMESPACE: ${process.env.KUBECTL_NAMESPACE}`);
+          const podNameDebug = await bash.runCommand('echo "$KUBECTL_NAMESPACE"');
           console.log(`#### ### ## podNameDebug: ${podNameDebug}`);
         }
 
         // get all pods that match the provided label
-        const podsNames = await bash.runCommand(`g3kubectl get pod --sort-by=.metadata.creationTimestamp -l app=${labelName} -o jsonpath="{.items[*].metadata.name}" | awk "{print $NF}"`);
+        const podsNames = await bash.runCommand(`g3kubectl get pod --sort-by=.metadata.creationTimestamp -l app=${labelName} -o jsonpath="{.items[*].metadata.name}"`);
         console.log(`Found pods with label '${labelName}': ${podsNames}`);
 
         // if there's more than 1 pod matching the provided name, the last one


### PR DESCRIPTION
In this nightly build: https://github.com/uc-cdis/cdis-manifest/pull/4752

Multiple pods match the provided label `gen3job`, so the command to check if the job succeeded `g3kubectl get pod <pod name>` is given multiple pod names, so we don't get the job status and we keep waiting for the job to complete long after it's done:

```
waiting for google-manage-keys to finish

waiting for google-manage-keys job pod... - attempt 1
### THE KUBECTL_NAMESPACE: jenkins-genomel

latest pod found: fence-db-migrate-7js8x fence-db-migrate-whm6c fence-db-migrate-29lrn fence-db-migrate-ck98q fence-db-migrate-j6r49 fence-db-migrate-d2mrm gdcdb-create-9ndn8 indexd-userdb-xnbtc fence-db-migrate-kjz9k google-verify-bucket-access-group-x7l2m fence-visa-update-27588990-klnfc gentestdata-bgnfb etl-m4l6t useryaml-dfk8r usersync-2bc9q fence-cleanup-expired-ga4gh-info-27589010-7ggrs fence-cleanup-expired-ga4gh-info-27589015-fwpn8 google-manage-keys-gc8wh google-manage-keys-m4sbz

the pod fence-db-migrate-7js8x fence-db-migrate-whm6c fence-db-migrate-29lrn fence-db-migrate-ck98q fence-db-migrate-j6r49 fence-db-migrate-d2mrm gdcdb-create-9ndn8 indexd-userdb-xnbtc fence-db-migrate-kjz9k google-verify-bucket-access-group-x7l2m fence-visa-update-27588990-klnfc gentestdata-bgnfb etl-m4l6t useryaml-dfk8r usersync-2bc9q fence-cleanup-expired-ga4gh-info-27589010-7ggrs fence-cleanup-expired-ga4gh-info-27589015-fwpn8 google-manage-keys-gc8wh google-manage-keys-m4sbz was found! Proceed with the container check...

waiting for google-manage-keys job pod... - attempt 2
    I refresh page 
### THE KUBECTL_NAMESPACE: jenkins-genomel

latest pod found: fence-db-migrate-7js8x fence-db-migrate-whm6c fence-db-migrate-29lrn fence-db-migrate-ck98q fence-db-migrate-j6r49 fence-db-migrate-d2mrm gdcdb-create-9ndn8 indexd-userdb-xnbtc fence-db-migrate-kjz9k google-verify-bucket-access-group-x7l2m fence-visa-update-27588990-klnfc gentestdata-bgnfb etl-m4l6t useryaml-dfk8r usersync-2bc9q fence-cleanup-expired-ga4gh-info-27589010-7ggrs fence-cleanup-expired-ga4gh-info-27589015-fwpn8 google-manage-keys-gc8wh google-manage-keys-m4sbz

check container status: 
waiting for google-manage-keys job pod... - attempt 3

etc
```

### Bug Fixes
- Fix `checkPod` logic to only select 1 pod
