### PR TITLE
adding host to ingore

### DIFF
--- a/suites/portal/dataguidOrgTest.js
+++ b/suites/portal/dataguidOrgTest.js
@@ -51,7 +51,7 @@ BeforeSuite(async ({ I }) => {
   const hosts = await getAllHost();
   for (let i = 0; i < hosts.length; i += 1) {
     // skip hosts not owned by CTDS
-    if (!hosts[i].includes('repo.data.nesi.org.nz') && !hosts[i].includes('data.agdr.org.nz')) {
+    if (!hosts[i].includes('repo.data.nesi.org.nz') && !hosts[i].includes('data.agdr.org.nz') && !hosts[i].includes('gen3.agha.umccr.org')) {
       const guid = await getFirstGuidFromHost(hosts[i], I);
       I.cache.correctGuids.push(guid);
     }


### PR DESCRIPTION
adding `https://gen3.agha.umccr.org/` to the check as its goes down occasionally and we cannot control it

when the host is down, the test keeps failing. Adding to the check will ignore the host and move forward

