### PR TITLE
Disabling drsEndpoint test in jenkins

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -313,6 +313,9 @@ donot '@prjsBucketAccess'
 echo "INFO: disabling RAS DRS test as jenkins env is not configured"
 donot '@rasDRS'
 
+# disabling drsEndpoint tests
+donot @drs
+
 # For dataguids.org PRs, skip all fence-related bootstrapping oprations
 # as the environment does not have fence
 if [ "$testedEnv" == "dataguids.org" ]; then


### PR DESCRIPTION
Jira Ticket: NA

### New Features

- disable drs endpoint test because it is blocking merge to portal and also failing nightly build