### PR TITLE
fix(install-pypfb): ensure pip is up to date

### DIFF
--- a/suites/portal/pfbExportTest.js
+++ b/suites/portal/pfbExportTest.js
@@ -409,7 +409,7 @@ Scenario('Install the latest pypfb CLI version and make sure we can parse the av
   // the previous test did not create it
   expect(files.fileExists(`./test_export_${I.cache.UNIQUE_NUM}.avro`), 'A "test_export_<unique number>.avro" file should have been created by previous test').to.be.true;
 
-  const pyPfbInstallationOutput = await bash.runCommand(`python3.8 -m venv pfb_test && source pfb_test/bin/activate && pip install pypfb && ${I.cache.WORKSPACE}/gen3-qa/pfb_test/bin/pfb`);
+  const pyPfbInstallationOutput = await bash.runCommand(`python3.8 -m venv pfb_test && source pfb_test/bin/activate && pip install --upgrade pip && pip install pypfb && ${I.cache.WORKSPACE}/gen3-qa/pfb_test/bin/pfb`);
   if (process.env.DEBUG === 'true') {
     console.log(`${new Date()}: pyPfbInstallationOutput = ${pyPfbInstallationOutput}`);
   }


### PR DESCRIPTION
Nightly build test PFB Export `@requires-portal @e2e Install the latest pypfb CLI version and make sure we can parse the avro file @pfbExport – Install the latest pypfb CLI version and make sure we can parse the avro file @pfbExport` failed twice in a row when using the BDC environment last night and today.

Looks like the cryptography/Rust compiler issue. The test is using Python 3.8 (instead of 3.9, not sure why) but the simple solution is to ensure that we upgrade pip before attempting to install pypfb in the test. I have a PR to do so here: 
```
  Failed to build cryptography
  ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
  WARNING: You are using pip version 19.2.3, however version 22.3.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.
```

### New Features


### Breaking Changes


### Bug Fixes
- Fix broken nightly build by ensuring pip is updated before installing pypfb

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
