### PR TITLE
Get chrome version and use the value to install chromedriver

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -593,9 +593,8 @@ if [[ "$(hostname)" == *"cdis-github-org"* ]] || [[ "$(hostname)" == *"planx-ci-
   
   # Start selenium process within the ephemeral jenkins pod.
   # npx selenium-standalone install --version=4.0.0-alpha-7 --drivers.chrome.version=96.0.4664.45 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
-  # timeout $seleniumTimeout npx selenium-standalone start --version=4.0.0-alpha-7 --drivers.chrome.version=96.0.4664.45 &> selenium.log &
-  # npm install selenium-standalone --save-dev
-  timeout $seleniumTimeout npx selenium-standalone install && npx selenium-standalone start &
+  chromeVersion=$(google-chrome --version | grep -Eo '[0-9.]{10,20}')
+  timeout $seleniumTimeout npx selenium-standalone install --drivers.chrome.version=$chromeVersion && npx selenium-standalone start &
 
   # gen3-qa-in-a-box requires a couple of changes to its webdriver config
   set +e

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -594,7 +594,8 @@ if [[ "$(hostname)" == *"cdis-github-org"* ]] || [[ "$(hostname)" == *"planx-ci-
   # Start selenium process within the ephemeral jenkins pod.
   # npx selenium-standalone install --version=4.0.0-alpha-7 --drivers.chrome.version=96.0.4664.45 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
   chromeVersion=$(google-chrome --version | grep -Eo '[0-9.]{10,20}')
-  timeout $seleniumTimeout npx selenium-standalone install --drivers.chrome.version=$chromeVersion && npx selenium-standalone start &
+  npx selenium-standalone install --drivers.chrome.version=$chromeVersion --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
+  timeout $seleniumTimeout npx selenium-standalone start
 
   # gen3-qa-in-a-box requires a couple of changes to its webdriver config
   set +e

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -595,7 +595,7 @@ if [[ "$(hostname)" == *"cdis-github-org"* ]] || [[ "$(hostname)" == *"planx-ci-
   # npx selenium-standalone install --version=4.0.0-alpha-7 --drivers.chrome.version=96.0.4664.45 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
   chromeVersion=$(google-chrome --version | grep -Eo '[0-9.]{10,20}')
   npx selenium-standalone install --drivers.chrome.version=$chromeVersion --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
-  timeout $seleniumTimeout npx selenium-standalone start
+  timeout $seleniumTimeout npx selenium-standalone start --drivers.chrome.version=$chromeVersion
 
   # gen3-qa-in-a-box requires a couple of changes to its webdriver config
   set +e

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -595,7 +595,7 @@ if [[ "$(hostname)" == *"cdis-github-org"* ]] || [[ "$(hostname)" == *"planx-ci-
   # npx selenium-standalone install --version=4.0.0-alpha-7 --drivers.chrome.version=96.0.4664.45 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
   chromeVersion=$(google-chrome --version | grep -Eo '[0-9.]{10,20}')
   npx selenium-standalone install --drivers.chrome.version=$chromeVersion --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
-  timeout $seleniumTimeout npx selenium-standalone start --drivers.chrome.version=$chromeVersion
+  timeout $seleniumTimeout npx selenium-standalone start --drivers.chrome.version=$chromeVersion &
 
   # gen3-qa-in-a-box requires a couple of changes to its webdriver config
   set +e


### PR DESCRIPTION
It looks like chromedriver can get updated to support non-stable chrome versions (109 was released which chrome stable version was 108.xx)

Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
