### PR TITLE
Improve core metadata test errors

### DIFF
--- a/services/apis/fence/fenceTasks.js
+++ b/services/apis/fence/fenceTasks.js
@@ -498,8 +498,9 @@ module.exports = {
   async getConsentCode(clientId, responseType, scope, consent = 'ok', expectCode = true) {
     const fullURL = `https://${process.env.HOSTNAME}${fenceProps.endpoints.authorizeOAuth2Client}?response_type=${responseType}&client_id=${clientId}&redirect_uri=https://${process.env.HOSTNAME}&scope=${scope}`;
     if (process.env.DEBUG === 'true') {
-      console.log(fullURL);
+      console.log('fenceTasks.getConsentCode fullURL:', fullURL);
     }
+
     I.amOnPage(fullURL);
     if (process.env.DEBUG === 'true') {
       I.saveScreenshot('getConsentCode.png');

--- a/services/apis/peregrine/peregrineTasks.js
+++ b/services/apis/peregrine/peregrineTasks.js
@@ -1,8 +1,11 @@
+const chai = require('chai');
+
 const semver = require('semver');
 
 const peregrineProps = require('./peregrineProps.js');
 const user = require('../../../utils/user.js');
 
+const { expect } = chai;
 const I = actor();
 
 /**
@@ -121,7 +124,7 @@ module.exports = {
   },
 
   async getCoremetadata(
-    file, format = 'application/json', access_token,
+    file, format = 'application/json', access_token, expected_status_code=200
   ) {
     const token = {
       Accept: format,
@@ -157,6 +160,8 @@ module.exports = {
     });
 
     const endpoint = `${url}/${file.did}`;
-    return I.sendGetRequest(endpoint, token).then((res) => res.data);
+    const res = await I.sendGetRequest(endpoint, token);
+    expect(res, 'Unable to get core metadata').to.have.property('status', expected_status_code);
+    return res.data;
   },
 };

--- a/suites/coremetadata/getCoremetadataTest.js
+++ b/suites/coremetadata/getCoremetadataTest.js
@@ -21,13 +21,13 @@ Scenario('test core metadata @coreMetadata', async ({ peregrine, users }) => {
 });
 
 Scenario('test core metadata invalid object_id @coreMetadata', async ({ peregrine, users }) => {
-  const data = await peregrine.do.getCoremetadata(invalid_id_file, 'application/json', users.mainAcct.accessTokenHeader);
+  const data = await peregrine.do.getCoremetadata(invalid_id_file, 'application/json', users.mainAcct.accessTokenHeader, 404);
   peregrine.ask.seeCoreMetadataError(data);
 });
 
 Scenario('test core metadata no permission @coreMetadata', async ({ peregrine }) => {
   const invalid_token = { Authorization: 'invalid' };
-  const data = await peregrine.do.getCoremetadata(valid_file, 'application/json', invalid_token);
+  const data = await peregrine.do.getCoremetadata(valid_file, 'application/json', invalid_token, 401);
   peregrine.ask.seeCoreMetadataError(data);
 });
 


### PR DESCRIPTION


### Improvements
- Improve core metadata test errors: check that the request succeeded before checking the fields in the response
