### PR TITLE
removing the "doc_type" field 

### DIFF
--- a/suites/guppy/jenkinsSetup/canineData/arrayMapping.json
+++ b/suites/guppy/jenkinsSetup/canineData/arrayMapping.json
@@ -1,13 +1,11 @@
 {
     "mappings" : {
-      "_doc" : {
-        "properties" : {
-          "array" : {
-            "type" : "keyword"
-          },
-          "timestamp" : {
-            "type" : "date"
-          }
+      "properties" : {
+        "array" : {
+          "type" : "keyword"
+        },
+        "timestamp" : {
+          "type" : "date"
         }
       }
     }

--- a/suites/guppy/jenkinsSetup/canineData/fileMapping.json
+++ b/suites/guppy/jenkinsSetup/canineData/fileMapping.json
@@ -1,49 +1,47 @@
 {
     "mappings" : {
-      "file" : {
-        "properties" : {
-          "auth_resource_path" : {
-            "type" : "keyword"
-          },
-          "data_format" : {
-            "type" : "keyword"
-          },
-          "data_type" : {
-            "type" : "keyword"
-          },
-          "file_id" : {
-            "type" : "keyword"
-          },
-          "file_name" : {
-            "type" : "keyword"
-          },
-          "file_size" : {
-            "type" : "long"
-          },
-          "md5sum" : {
-            "type" : "keyword"
-          },
-          "node_id" : {
-            "type" : "keyword"
-          },
-          "object_id" : {
-            "type" : "keyword"
-          },
-          "program_name" : {
-            "type" : "keyword"
-          },
-          "project_code" : {
-            "type" : "keyword"
-          },
-          "project_id" : {
-            "type" : "keyword"
-          },
-          "state" : {
-            "type" : "keyword"
-          },
-          "subject_id" : {
-            "type" : "keyword"
-          }
+      "properties" : {
+        "auth_resource_path" : {
+          "type" : "keyword"
+        },
+        "data_format" : {
+          "type" : "keyword"
+        },
+        "data_type" : {
+          "type" : "keyword"
+        },
+        "file_id" : {
+          "type" : "keyword"
+        },
+        "file_name" : {
+          "type" : "keyword"
+        },
+        "file_size" : {
+          "type" : "long"
+        },
+        "md5sum" : {
+          "type" : "keyword"
+        },
+        "node_id" : {
+          "type" : "keyword"
+        },
+        "object_id" : {
+          "type" : "keyword"
+        },
+        "program_name" : {
+          "type" : "keyword"
+        },
+        "project_code" : {
+          "type" : "keyword"
+        },
+        "project_id" : {
+          "type" : "keyword"
+        },
+        "state" : {
+          "type" : "keyword"
+        },
+        "subject_id" : {
+          "type" : "keyword"
         }
       }
     }

--- a/suites/guppy/jenkinsSetup/canineData/subjectMapping.json
+++ b/suites/guppy/jenkinsSetup/canineData/subjectMapping.json
@@ -1,82 +1,80 @@
 {
     "mappings" : {
-      "subject" : {
-        "properties" : {
-          "_aggregated_genotyping_arrays_count" : {
-            "type" : "float"
-          },
-          "_aliquots_count" : {
-            "type" : "float"
-          },
-          "_copy_number_estimates_count" : {
-            "type" : "float"
-          },
-          "_copy_numer_segments_count" : {
-            "type" : "float"
-          },
-          "_genotyping_arrays_count" : {
-            "type" : "float"
-          },
-          "_mRNA_microarrays_count" : {
-            "type" : "float"
-          },
-          "_read_groups_count" : {
-            "type" : "float"
-          },
-          "_samples_count" : {
-            "type" : "float"
-          },
-          "_submitted_aligned_reads_count" : {
-            "type" : "float"
-          },
-          "_submitted_genomic_profiles_count" : {
-            "type" : "float"
-          },
-          "_submitted_methylations_count" : {
-            "type" : "float"
-          },
-          "_submitted_unaligned_reads_count" : {
-            "type" : "float"
-          },
-          "_tangent_copy_numbers_count" : {
-            "type" : "float"
-          },
-          "auth_resource_path" : {
-            "type" : "keyword"
-          },
-          "breed" : {
-            "type" : "keyword"
-          },
-          "data_format" : {
-            "type" : "keyword"
-          },
-          "data_type" : {
-            "type" : "keyword"
-          },
-          "disease_type" : {
-            "type" : "keyword"
-          },
-          "file_id" : {
-            "type" : "keyword"
-          },
-          "gender" : {
-            "type" : "keyword"
-          },
-          "node_id" : {
-            "type" : "keyword"
-          },
-          "primary_site" : {
-            "type" : "keyword"
-          },
-          "project_id" : {
-            "type" : "keyword"
-          },
-          "subject_id" : {
-            "type" : "keyword"
-          },
-          "submitter_id" : {
-            "type" : "keyword"
-          }
+      "properties" : {
+        "_aggregated_genotyping_arrays_count" : {
+          "type" : "float"
+        },
+        "_aliquots_count" : {
+          "type" : "float"
+        },
+        "_copy_number_estimates_count" : {
+          "type" : "float"
+        },
+        "_copy_numer_segments_count" : {
+          "type" : "float"
+        },
+        "_genotyping_arrays_count" : {
+          "type" : "float"
+        },
+        "_mRNA_microarrays_count" : {
+          "type" : "float"
+        },
+        "_read_groups_count" : {
+          "type" : "float"
+        },
+        "_samples_count" : {
+          "type" : "float"
+        },
+        "_submitted_aligned_reads_count" : {
+          "type" : "float"
+        },
+        "_submitted_genomic_profiles_count" : {
+          "type" : "float"
+        },
+        "_submitted_methylations_count" : {
+          "type" : "float"
+        },
+        "_submitted_unaligned_reads_count" : {
+          "type" : "float"
+        },
+        "_tangent_copy_numbers_count" : {
+          "type" : "float"
+        },
+        "auth_resource_path" : {
+          "type" : "keyword"
+        },
+        "breed" : {
+          "type" : "keyword"
+        },
+        "data_format" : {
+          "type" : "keyword"
+        },
+        "data_type" : {
+          "type" : "keyword"
+        },
+        "disease_type" : {
+          "type" : "keyword"
+        },
+        "file_id" : {
+          "type" : "keyword"
+        },
+        "gender" : {
+          "type" : "keyword"
+        },
+        "node_id" : {
+          "type" : "keyword"
+        },
+        "primary_site" : {
+          "type" : "keyword"
+        },
+        "project_id" : {
+          "type" : "keyword"
+        },
+        "subject_id" : {
+          "type" : "keyword"
+        },
+        "submitter_id" : {
+          "type" : "keyword"
         }
       }
     }

--- a/suites/guppy/jenkinsSetup/canineData/toyMapping.json
+++ b/suites/guppy/jenkinsSetup/canineData/toyMapping.json
@@ -1,10 +1,8 @@
 {
     "mappings" : {
-      "thing" : {
-        "properties" : {
-          "auth_resource_path" : {
-            "type" : "keyword"
-          }
+      "properties" : {
+        "auth_resource_path" : {
+          "type" : "keyword"
         }
       }
     }


### PR DESCRIPTION
removing the "doc_type" field from the index mapping as ES7 no longer supports it and we are moving Jenkins over to ES7.