### PR TITLE
Revert "enabling GWASUi Test for CI checks"

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -323,8 +323,8 @@ donot '@prjsBucketAccess'
 echo "INFO: disabling RAS DRS test as jenkins env is not configured"
 donot '@rasDRS'
 
-# echo "INFO: temporarily disabling GWAS UI tests as jenkins envs are not still configured"
-# donot '@GWASUI'
+echo "INFO: temporarily disabling GWAS UI tests as jenkins envs are not still configured"
+donot '@GWASUI'
 
 # For dataguids.org PRs, skip all fence-related bootstrapping oprations
 # as the environment does not have fence


### PR DESCRIPTION
PRs are failing with these tests now. We should test deploying GWAS to environments using a branch with these changes, so reverting the PR until the envs are updated