### PR TITLE
Fix re-submission failure when dictionary does not allow multiple links

### DIFF
--- a/services/apis/sheepdog/sheepdogQuestions.js
+++ b/services/apis/sheepdog/sheepdogQuestions.js
@@ -22,12 +22,16 @@ module.exports = {
     const msg = `${message} - adding node ${JSON.stringify(copy, null, '  ')}`;
     try {
       expect(node.addRes, msg).to.be.a.gen3Res(sheepdogProps.resAddSuccess);
-    } catch (e) {
+    } catch (originalError) {
       if (allowUpdate) {
         console.log('Node creation check failed, but updates are allowed: check if successful update');
-        expect(node.addRes, msg).to.be.a.gen3Res(sheepdogProps.resUpdateSuccess);
+        try {
+          expect(node.addRes, msg).to.be.a.gen3Res(sheepdogProps.resUpdateSuccess);
+        } catch {
+          throw originalError;
+        }
       } else {
-        throw e;
+        throw originalError;
       }
     }
   },

--- a/suites/apis/dataUploadTest.js
+++ b/suites/apis/dataUploadTest.js
@@ -111,24 +111,18 @@ Scenario('File upload and download via API calls @dataUpload', async ({
 
   console.log(`${new Date()}: make sure we can link metadata to a file that already has metadata.`);
   // try to submit metadata for this file again
+  // `createNewParents=true` creates new nodes to avoid conflicts with the nodes already submitted by the
+  // previous `submitGraphAndFileMetadata()` call
   sheepdogRes = await nodes.submitGraphAndFileMetadata(
     sheepdog,
     fileGuid,
     fileSize,
     fileMd5,
     'submitter_id_new_value',
+    null,
+    true,
   );
-  // this should succeed - unless the dictionary used does not allow multiple links to one of the parent nodes,
-  // in which case we should get a 400 INVALID_LINK error that we can ignore. Any other error is abnormal.
-  try {
-    sheepdog.ask.addNodeSuccess(sheepdogRes);
-  } catch (originalError) {
-    try {
-      sheepdog.ask.hasEntityError(sheepdogRes.addRes, 'INVALID_LINK');
-    } catch {
-      throw originalError;
-    }
-  }
+  sheepdog.ask.addNodeSuccess(sheepdogRes);
 }).retry(1);
 
 /**
@@ -292,12 +286,16 @@ Scenario('Upload the same file twice @dataUpload', async ({
   await dataUpload.waitUploadFileUpdatedFromIndexdListener(indexd, fileNode);
 
   // submit metadata for this file
+  // `createNewParents=true` creates new nodes to avoid conflicts with the nodes already submitted by the
+  // previous `submitGraphAndFileMetadata()` call
   sheepdogRes = await nodes.submitGraphAndFileMetadata(
     sheepdog,
     fileGuid,
     fileSize,
     fileMd5,
     'submitter_id_new_value',
+    null,
+    true,
   );
   sheepdog.ask.addNodeSuccess(sheepdogRes, 'second upload');
 

--- a/utils/nodes.js
+++ b/utils/nodes.js
@@ -170,8 +170,11 @@ const getNodeWithSubmitterId = function (submitterId) {
 
 /**
  * Recursively steps through nodes from bottom to top looking for links, and submit all linked nodes.
+ *
+ * @param {boolean} newSubmitterIds - false by default, submit the nodes as-is. If true, generate a new submitter ID
+ * before submitting each linked node.
  */
-const submitLinksForNode = async function (sheepdog, record) {
+const submitLinksForNode = async function (sheepdog, record, newSubmitterIds = false) {
   for (const prop in record.data) {
     // check if it's a link
     if (record.data[prop] && record.data[prop].hasOwnProperty('submitter_id')) {
@@ -185,6 +188,13 @@ const submitLinksForNode = async function (sheepdog, record) {
       }
       // submit the linked node's own linked nodes
       await submitLinksForNode(sheepdog, linkedNode);
+
+      if (newSubmitterIds) {
+        // `linkedNode` is a clone of the original node. Generate a new submitter ID.
+        const rand = Math.random().toString(36).substring(2, 7); // 5 random chars
+        linkedNode.data.submitter_id = `${linkedNode.data.type}_${rand}`;
+      }
+
       // submit the linked node.
       // allow updates: this node may have been submitted before if it's a parent to several other nodes.
       await sheepdog.complete.addNode(linkedNode, true);
@@ -352,8 +362,11 @@ module.exports = {
    *
    * /!\ this function does not include a check for success or
    * failure of the file node's submission, to allow for negative tests
+   *
+   * @param {boolean} createNewParents - false by default, submit the nodes as-is. If true, generate a new node
+   * with a new submitter IDs for each parent node.
    */
-  async submitGraphAndFileMetadata(sheepdog, fileGuid = null, fileSize = null, fileMd5 = null, submitter_id = null, consent_codes = null) {
+  async submitGraphAndFileMetadata(sheepdog, fileGuid = null, fileSize = null, fileMd5 = null, submitter_id = null, consent_codes = null, createNewParents = false) {
     // submit metadata with object id via sheepdog
     existingFileNode = module.exports.getFileNode()
     const metadata = existingFileNode.clone();
@@ -379,7 +392,7 @@ module.exports = {
     }
 
     // submit all nodes that are directly or indirectly linked to this one
-    await submitLinksForNode(sheepdog, metadata);
+    await submitLinksForNode(sheepdog, metadata, createNewParents);
 
     // delete the existing file node and replace it with the newly generated one, to avoid conflicts if
     // any of the links do not allow linking multiple file nodes to the same parent node.

--- a/utils/nodes.js
+++ b/utils/nodes.js
@@ -187,12 +187,14 @@ const submitLinksForNode = async function (sheepdog, record, newSubmitterIds = f
         throw new Error(`Record has a link to '${record.data[prop].submitter_id}' but we can't find that record`);
       }
       // submit the linked node's own linked nodes
-      await submitLinksForNode(sheepdog, linkedNode);
+      await submitLinksForNode(sheepdog, linkedNode, newSubmitterIds);
 
-      if (newSubmitterIds) {
-        // `linkedNode` is a clone of the original node. Generate a new submitter ID.
+      if (newSubmitterIds) { // generate a new submitter ID
         const rand = Math.random().toString(36).substring(2, 7); // 5 random chars
-        linkedNode.data.submitter_id = `${linkedNode.data.type}_${rand}`;
+        const newId = `${linkedNode.data.type}_${rand}`;
+        console.log(`Updating link from '${record.data[prop].submitter_id}' to new record '${newId}'`);
+        linkedNode.data.submitter_id = newId; // `addNode` will create a new record since it's a new ID
+        record.data[prop].submitter_id = newId; // update the link to reference the new node
       }
 
       // submit the linked node.


### PR DESCRIPTION
Extract from the logs of failure with IBD dictionary:
```
submit metadata for this file
new metadata.data: {"core_metadata_collections":{"submitter_id":"core_metadata_collection_fullback_Oslo's"},"data_category":"Sequencing Data","data_format":"BAM","data_type":"Unaligned Reads","experimental_strategy":"Validation","file_name":"ash_showpiece's","file_size":77,"md5sum":"446557db934c847ec94d37e4f066f55f","read_groups":{"submitter_id":"read_group_acceptance_fructified"},"submitter_id":"submitted_unaligned_reads_poles_Myrdal","type":"submitted_unaligned_reads","object_id":"aaf97e60-e0b8-49a8-ac93-443fc0e7ce87"}
[succeeds]

[...]

check that we cannot link metadata to a file that already has metadata.
new metadata.data: {"core_metadata_collections":{"submitter_id":"core_metadata_collection_fullback_Oslo's"},"data_category":"Sequencing Data","data_format":"BAM","data_type":"Unaligned Reads","experimental_strategy":"Validation","file_name":"ash_showpiece's","file_size":77,"md5sum":"446557db934c847ec94d37e4f066f55f","read_groups":{"submitter_id":"read_group_acceptance_fructified"},"submitter_id":"submitter_id_new_value","type":"submitted_unaligned_reads","object_id":"aaf97e60-e0b8-49a8-ac93-443fc0e7ce87"}
[returns 400]
"message":"'read_groups' link has to be one_to_many, target node read_group already has submitted_unaligned_reads_files",
"type":"INVALID_LINK"
```

Fix by submitting new parents nodes.

Also fix comment that should read "make sure we can link metadata to a file that already has metadata" instead of "check that we cannot link metadata to a file that already has metadata" but was reverted by mistake in this old commit: https://github.com/uc-cdis/gen3-qa/commit/5b893776ce392c197aea02a7444bc47fd9dcdb22

### Improvements
- Add `createNewParents=t/f` flag to `submitGraphAndFileMetadata()` function to submit new parents nodes instead of only a new leaf node, to avoid metadata re-submission failures when the dictionary does not allow linking multiple leaf nodes to the same parent node.
