### PR TITLE
Run pfbExport tests for cdis-manifest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -526,7 +526,7 @@ elif ! (g3kubectl get pods --no-headers -l app=hatchery | grep hatchery) > /dev/
   donot '@exportToWorkspacePortalHatchery'
 fi
 
-if [[ "$service" != "pelican" || "$service" != "tube" ]]; then
+if [[ "$service" != "pelican" || "$service" != "tube" || "$service" != "cdis-manifest" ]]; then
   donot '@pfbExport'
 fi
 


### PR DESCRIPTION
We should run pfbExport tests in nightly builds but the test run conditions prevent it, so added an extra condition

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
